### PR TITLE
Allow adding multiple criterias.

### DIFF
--- a/src/Ardalis.Specification/BaseSpecification.cs
+++ b/src/Ardalis.Specification/BaseSpecification.cs
@@ -73,7 +73,7 @@ namespace Ardalis.Specification
             Guard.Against.NullOrEmpty(specificationName, nameof(specificationName));
 
             // Just to be able to throw exception if the list is empty. "Guard.Against.EmptyList" might be nice extension for GuardClauses.
-            Expression<Func<T, bool>> criteria = Criterias.Count() < 1 ? null : Criterias.FirstOrDefault();
+            var criteria = Criterias.FirstOrDefault();
             Guard.Against.Null(criteria, nameof(criteria));
 
             CacheKey = $"{specificationName}-{string.Join("-", args)}";

--- a/src/Ardalis.Specification/ISpecification.cs
+++ b/src/Ardalis.Specification/ISpecification.cs
@@ -9,7 +9,7 @@ namespace Ardalis.Specification
         bool CacheEnabled { get; }
         string CacheKey { get; }
 
-        Expression<Func<T, bool>> Criteria { get; }
+        IEnumerable<Expression<Func<T, bool>>> Criterias { get; }
         IEnumerable<Expression<Func<T, object>>> Includes { get; }
         IEnumerable<string> IncludeStrings { get; }
 

--- a/src/Ardalis.Specification/SpecificationEvaluator.cs
+++ b/src/Ardalis.Specification/SpecificationEvaluator.cs
@@ -9,9 +9,10 @@ namespace Ardalis.Specification
             var query = inputQuery;
 
             // modify the IQueryable using the specification's criteria expression
-            if (specification.Criteria != null)
+            if (specification.Criterias.Count() > 0)
             {
-                query = query.Where(specification.Criteria);
+                query = specification.Criterias.Aggregate(query,
+                                    (current, criteria) => current.Where(criteria));
             }
 
             // Apply ordering if expressions are set


### PR DESCRIPTION
Allow adding multiple criterias in the constructor body, by calling AddCriteria(criteria) method.
This would offer the following advantages
- Adding criteria (where clause) based on some condition.
- Adding multiple conditions in more clean fashion, instead of using "&" in a long expression as a constructor parameter.

In addition, having parameterless constructor, would offer creating empty specifications. This might be quite useful feature. Whenever we need list of all records, we can start with empty specification. If afterward, we require some global filter for particular entity, we can add the criteria in the empty specification.