### PR TITLE
Improving the selector functionality.

### DIFF
--- a/src/Ardalis.Specification/BaseSpecification.cs
+++ b/src/Ardalis.Specification/BaseSpecification.cs
@@ -6,6 +6,15 @@ using System.Linq.Expressions;
 
 namespace Ardalis.Specification
 {
+    // Keeping both classes here for clarity. Will fix it afterward
+
+    public abstract class BaseSpecification<T, TResult> : BaseSpecification<T>, ISpecification<T, TResult>
+    {
+        protected BaseSpecification(Expression<Func<T, bool>> criteria) : base(criteria) { }
+
+        public Expression<Func<T, TResult>> Selector { get; set; }
+    }
+
     public abstract class BaseSpecification<T> : ISpecification<T>
     {
         protected BaseSpecification(Expression<Func<T, bool>> criteria)
@@ -25,8 +34,6 @@ namespace Ardalis.Specification
 
         public string CacheKey { get; protected set; }
         public bool CacheEnabled { get; private set; }
-
-        public Func<T, object> Selector { get; set; }
 
         protected virtual void AddInclude(Expression<Func<T, object>> includeExpression)
         {

--- a/src/Ardalis.Specification/EfSpecificationEvaluator.cs
+++ b/src/Ardalis.Specification/EfSpecificationEvaluator.cs
@@ -5,7 +5,7 @@ namespace Ardalis.Specification
 {
     // Keeping both classes here for clarity. Will fix it afterward
 
-    public class EfSpecificationEvaluator<T, TId, TResult> : EfSpecificationEvaluator<T, TId> where T : class, IEntity<TId>
+    public class EfSpecificationEvaluator<T, TId, TResult> where T : class, IEntity<TId>
     {
         public static IQueryable<TResult> GetQuery(IQueryable<T> inputQuery, ISpecification<T, TResult> specification)
         {

--- a/src/Ardalis.Specification/EfSpecificationEvaluator.cs
+++ b/src/Ardalis.Specification/EfSpecificationEvaluator.cs
@@ -3,6 +3,21 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Ardalis.Specification
 {
+    // Keeping both classes here for clarity. Will fix it afterward
+
+    public class EfSpecificationEvaluator<T, TId, TResult> : EfSpecificationEvaluator<T, TId> where T : class, IEntity<TId>
+    {
+        public static IQueryable<TResult> GetQuery(IQueryable<T> inputQuery, ISpecification<T, TResult> specification)
+        {
+            var query = EfSpecificationEvaluator<T, TId>.GetQuery(inputQuery, specification);
+
+            // Apply selector
+            var selectQuery = query.Select(specification.Selector);
+
+            return selectQuery;
+        }
+    }
+
     public class EfSpecificationEvaluator<T, TId> where T : class, IEntity<TId>
     {
         public static IQueryable<T> GetQuery(IQueryable<T> inputQuery, ISpecification<T> specification)
@@ -18,9 +33,6 @@ namespace Ardalis.Specification
             // Include any string-based include statements
             query = specification.IncludeStrings.Aggregate(query,
                                     (current, include) => current.Include(include));
-
-            // Apply selector
-            // query = query.Select(specification.Selector);
 
             return query;
         }

--- a/src/Ardalis.Specification/ISpecification.cs
+++ b/src/Ardalis.Specification/ISpecification.cs
@@ -4,6 +4,13 @@ using System.Linq.Expressions;
 
 namespace Ardalis.Specification
 {
+    // Keeping both interfaces here for clarity. Will fix it afterward
+
+    public interface ISpecification<T, TResult> : ISpecification<T>
+    {
+        Expression<Func<T, TResult>> Selector { get; set; }
+    }
+
     public interface ISpecification<T>
     {
         bool CacheEnabled { get; }
@@ -20,7 +27,5 @@ namespace Ardalis.Specification
         int Take { get; }
         int Skip { get; }
         bool IsPagingEnabled { get; }
-
-        Func<T, object> Selector { get; }
     }
 }

--- a/tests/Ardalis.Specification.IntegrationTests/SampleClient/EfRepository.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleClient/EfRepository.cs
@@ -35,13 +35,12 @@ namespace Ardalis.Specification.IntegrationTests.SampleClient
             return await ApplySpecification(spec).ToListAsync();
         }
 
-        public async Task<IReadOnlyList<object>> ListWithProjectionAsync(ISpecification<T> spec)
+        public async Task<IReadOnlyList<TResult>> ListWithProjectionAsync<TResult>(ISpecification<T, TResult> spec)
         {
             if (spec is null) throw new ArgumentNullException("spec is required");
-            var subResult = ApplySpecification(spec);
-
             if (spec.Selector is null) throw new Exception("Specification must have Selector defined.");
-            return subResult.Select(spec.Selector).ToList();
+
+            return await ApplySpecification(spec).ToListAsync();
         }
 
         public async Task<int> CountAsync(ISpecification<T> spec)
@@ -72,6 +71,11 @@ namespace Ardalis.Specification.IntegrationTests.SampleClient
         private IQueryable<T> ApplySpecification(ISpecification<T> spec)
         {
             return EfSpecificationEvaluator<T, int>.GetQuery(_dbContext.Set<T>().AsQueryable(), spec);
+        }
+
+        private IQueryable<TResult> ApplySpecification<TResult>(ISpecification<T, TResult> spec)
+        {
+            return EfSpecificationEvaluator<T, int, TResult>.GetQuery(_dbContext.Set<T>().AsQueryable(), spec);
         }
     }
 }

--- a/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/BlogNamesSpecification.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/BlogNamesSpecification.cs
@@ -2,7 +2,7 @@
 
 namespace Ardalis.Specification.IntegrationTests.SampleSpecs
 {
-    public class BlogNamesSpecification : BaseSpecification<Blog>
+    public class BlogNamesSpecification : BaseSpecification<Blog, object>
     {
         public BlogNamesSpecification() : base(b => true)
         {

--- a/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/BlogNamesSpecification.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/BlogNamesSpecification.cs
@@ -2,7 +2,12 @@
 
 namespace Ardalis.Specification.IntegrationTests.SampleSpecs
 {
-    public class BlogNamesSpecification : BaseSpecification<Blog, object>
+    // [fiseni, 11/22/2019] All the complexity of this infrastructure is hidden from the users.
+    // This is the only place where they will face the second generic parameter of the specifications.
+    // And, probably this is the right place for that. 
+    // This is the place where they define the expression for the selector, and it's the same place where they define the type of the output as well.
+    // You do this once, and u never worry anymore while consuming the repo. Strongly typed, no casting involved.
+    public class BlogNamesSpecification : BaseSpecification<Blog, string>
     {
         public BlogNamesSpecification() : base(b => true)
         {

--- a/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/PostSelectSpecification.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/PostSelectSpecification.cs
@@ -1,11 +1,12 @@
 ﻿using Ardalis.Specification.IntegrationTests.SampleClient;
 using System;
+using System.Linq.Expressions;
 
 namespace Ardalis.Specification.IntegrationTests.SampleSpecs
 {
-    public class PostSelectSpecification : BaseSpecification<Post>
+    public class PostSelectSpecification : BaseSpecification<Post, object>
     {
-        public PostSelectSpecification(Func<Post,object> selector) : base(b => true)
+        public PostSelectSpecification(Expression<Func<Post, object>> selector) : base(b => true)
         {
             Selector = selector;
         }


### PR DESCRIPTION
The PR presents just another way to solve issues with selector functionality in the specification.
We keep selector evaluation within specification logic, and not delegating to the repository.