### PR TITLE
Feature/chainable includes

### DIFF
--- a/src/Ardalis.Specification/Ardalis.Specification.csproj
+++ b/src/Ardalis.Specification/Ardalis.Specification.csproj
@@ -33,4 +33,8 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="QueryExtensions\Include\" />
+  </ItemGroup>
+
 </Project>

--- a/src/Ardalis.Specification/BaseSpecification.cs
+++ b/src/Ardalis.Specification/BaseSpecification.cs
@@ -1,7 +1,7 @@
 ﻿using Ardalis.GuardClauses;
+using Ardalis.Specification.QueryExtensions.Include;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 
 namespace Ardalis.Specification
@@ -29,6 +29,11 @@ namespace Ardalis.Specification
         protected virtual void AddInclude(Expression<Func<T, object>> includeExpression)
         {
             ((List<Expression<Func<T, object>>>)Includes).Add(includeExpression);
+        }
+        protected virtual void AddIncludes<TProperty>(Func<IncludeAggregator<T>, IIncludeQuery<T, TProperty>> includeGenerator)
+        {
+            var includeQuery = includeGenerator(new IncludeAggregator<T>());
+            ((List<string>)IncludeStrings).AddRange(includeQuery.Paths);
         }
         protected virtual void AddInclude(string includeString)
         {

--- a/src/Ardalis.Specification/QueryExtensions/Include/IIncludeQuery.cs
+++ b/src/Ardalis.Specification/QueryExtensions/Include/IIncludeQuery.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace Ardalis.Specification.QueryExtensions.Include
+{
+    public interface IIncludeQuery
+    {
+        Dictionary<IIncludeQuery, string> PathMap { get; }
+        IncludeVisitor Visitor { get; }
+        HashSet<string> Paths { get; }
+    }
+
+    public interface IIncludeQuery<TEntity, out TPreviousProperty> : IIncludeQuery
+    {
+    }
+}

--- a/src/Ardalis.Specification/QueryExtensions/Include/IncludeAggregator.cs
+++ b/src/Ardalis.Specification/QueryExtensions/Include/IncludeAggregator.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Ardalis.Specification.QueryExtensions.Include
+{
+    public class IncludeAggregator<TEntity>
+    {
+        public IncludeQuery<TEntity, TProperty> Include<TProperty>(Expression<Func<TEntity, TProperty>> selector)
+        {
+            var visitor = new IncludeVisitor();
+            visitor.Visit(selector);
+
+            var pathMap = new Dictionary<IIncludeQuery, string>();
+            var query = new IncludeQuery<TEntity, TProperty>(pathMap);
+
+            if (!string.IsNullOrEmpty(visitor.Path))
+            {
+                pathMap[query] = visitor.Path;
+            }
+
+            return query;
+        }
+    }
+}

--- a/src/Ardalis.Specification/QueryExtensions/Include/IncludeQuery.cs
+++ b/src/Ardalis.Specification/QueryExtensions/Include/IncludeQuery.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+
+namespace Ardalis.Specification.QueryExtensions.Include
+{
+    public class IncludeQuery<TEntity, TPreviousProperty> : IIncludeQuery<TEntity, TPreviousProperty>
+    {
+        public Dictionary<IIncludeQuery, string> PathMap { get; } = new Dictionary<IIncludeQuery, string>();
+        public IncludeVisitor Visitor { get; } = new IncludeVisitor();
+
+        public IncludeQuery(Dictionary<IIncludeQuery, string> pathMap)
+        {
+            PathMap = pathMap;
+        }
+
+        // ToHashSet is only available if netstandard2.1 is used.
+        public HashSet<string> Paths
+        {
+            get
+            {
+                var pathSet = new HashSet<string>();
+
+                foreach (var kvp in PathMap)
+                {
+                    pathSet.Add(kvp.Value);
+                }
+
+                return pathSet;
+            }
+        }
+    }
+}

--- a/src/Ardalis.Specification/QueryExtensions/Include/IncludeQueryExtensions.cs
+++ b/src/Ardalis.Specification/QueryExtensions/Include/IncludeQueryExtensions.cs
@@ -24,7 +24,7 @@ namespace Ardalis.Specification.QueryExtensions.Include
         {
             query.Visitor.Visit(selector);
 
-            // If the visitor did not generated a path, return a new IncludeQuery with an unmodified PathMap.
+            // If the visitor did not generate a path, return a new IncludeQuery with an unmodified PathMap.
             if (string.IsNullOrEmpty(query.Visitor.Path))
             {
                 return new IncludeQuery<TEntity, TNewProperty>(query.PathMap);
@@ -46,7 +46,7 @@ namespace Ardalis.Specification.QueryExtensions.Include
         {
             query.Visitor.Visit(selector);
 
-            // If the visitor did not generated a path, return a new IncludeQuery with an unmodified PathMap.
+            // If the visitor did not generate a path, return a new IncludeQuery with an unmodified PathMap.
             if (string.IsNullOrEmpty(query.Visitor.Path))
             {
                 return new IncludeQuery<TEntity, TNewProperty>(query.PathMap);

--- a/src/Ardalis.Specification/QueryExtensions/Include/IncludeQueryExtensions.cs
+++ b/src/Ardalis.Specification/QueryExtensions/Include/IncludeQueryExtensions.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Ardalis.Specification.QueryExtensions.Include
+{
+    public static class IncludeQueryExtensions
+    {
+        public static IIncludeQuery<TEntity, TNewProperty> Include<TEntity, TPreviousProperty, TNewProperty>(
+            this IIncludeQuery<TEntity, TPreviousProperty> query,
+            Expression<Func<TEntity, TNewProperty>> selector)
+        {
+            query.Visitor.Visit(selector);
+
+            var includeQuery = new IncludeQuery<TEntity, TNewProperty>(query.PathMap);
+            query.PathMap[includeQuery] = query.Visitor.Path;
+
+            return includeQuery;
+        }
+
+        public static IIncludeQuery<TEntity, TNewProperty> ThenInclude<TEntity, TPreviousProperty, TNewProperty>(
+            this IIncludeQuery<TEntity, TPreviousProperty> query,
+            Expression<Func<TPreviousProperty, TNewProperty>> selector)
+        {
+            query.Visitor.Visit(selector);
+
+            // If the visitor did not generated a path, return a new IncludeQuery with an unmodified PathMap.
+            if (string.IsNullOrEmpty(query.Visitor.Path))
+            {
+                return new IncludeQuery<TEntity, TNewProperty>(query.PathMap);
+            }
+
+            var pathMap = query.PathMap;
+            var existingPath = pathMap[query];
+            pathMap.Remove(query);
+
+            var includeQuery = new IncludeQuery<TEntity, TNewProperty>(query.PathMap);
+            pathMap[includeQuery] = $"{existingPath}.{query.Visitor.Path}";
+
+            return includeQuery;
+        }
+
+        public static IIncludeQuery<TEntity, TNewProperty> ThenInclude<TEntity, TPreviousProperty, TNewProperty>(
+            this IIncludeQuery<TEntity, IEnumerable<TPreviousProperty>> query,
+            Expression<Func<TPreviousProperty, TNewProperty>> selector)
+        {
+            query.Visitor.Visit(selector);
+
+            // If the visitor did not generated a path, return a new IncludeQuery with an unmodified PathMap.
+            if (string.IsNullOrEmpty(query.Visitor.Path))
+            {
+                return new IncludeQuery<TEntity, TNewProperty>(query.PathMap);
+            }
+
+            var pathMap = query.PathMap;
+            var existingPath = pathMap[query];
+            pathMap.Remove(query);
+
+            var includeQuery = new IncludeQuery<TEntity, TNewProperty>(query.PathMap);
+            pathMap[includeQuery] = $"{existingPath}.{query.Visitor.Path}";
+
+            return includeQuery;
+        }
+    }
+}

--- a/src/Ardalis.Specification/QueryExtensions/Include/IncludeVisitor.cs
+++ b/src/Ardalis.Specification/QueryExtensions/Include/IncludeVisitor.cs
@@ -1,0 +1,16 @@
+﻿using System.Linq.Expressions;
+
+namespace Ardalis.Specification.QueryExtensions.Include
+{
+    public class IncludeVisitor : ExpressionVisitor
+    {
+        public string Path { get; private set; } = string.Empty;
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            Path = string.IsNullOrEmpty(Path) ? node.Member.Name : $"{node.Member.Name}.{Path}";
+
+            return base.VisitMember(node);
+        }
+    }
+}

--- a/tests/Ardalis.Specification.IntegrationTests/DatabaseCommunicationTests.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/DatabaseCommunicationTests.cs
@@ -87,6 +87,17 @@ namespace Ardalis.Specification.IntegrationTests
         }
 
         [Fact]
+        public async Task GetBlogWithPostsAndAuthorsWithChainableIncludeSpecShouldIncludePostsAndAuthors()
+        {
+            var result = (await _blogRepository.ListAsync(new BlogWithPostsAndAuthorSpec(BlogBuilder.VALID_BLOG_ID))).SingleOrDefault();
+
+            result.Should().NotBeNull();
+            result.Name.Should().Be(BlogBuilder.VALID_BLOG_NAME);
+            result.Posts.Count.Should().BeGreaterThan(100);
+            result.Posts.Select(p => p.Author).ToList().Count.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
         public async Task GetSecondPageOfPostsUsingPostsByBlogPaginatedSpec()
         {
             int pageSize = 10;

--- a/tests/Ardalis.Specification.IntegrationTests/SampleClient/Post.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleClient/Post.cs
@@ -8,5 +8,7 @@
 
         public string Content { get; set; }
         public string Title { get; set; }
+
+        public Author Author { get; set; }
     }
 }

--- a/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/BlogWithPostsAndAuthorSpec.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/BlogWithPostsAndAuthorSpec.cs
@@ -1,0 +1,16 @@
+﻿using Ardalis.Specification.IntegrationTests.SampleClient;
+using Ardalis.Specification.QueryExtensions.Include;
+
+namespace Ardalis.Specification.IntegrationTests.SampleSpecs
+{
+    public class BlogWithPostsAndAuthorSpec : BaseSpecification<Blog>
+    {
+        public BlogWithPostsAndAuthorSpec(int id) : base(b => b.Id == id)
+        {
+            AddIncludes(x =>
+             x.Include(b => b.Posts)
+                .ThenInclude(p => p.Author)
+            );
+        }
+    }
+}

--- a/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/Builders/IncludeQueryBuilder.cs
+++ b/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/Builders/IncludeQueryBuilder.cs
@@ -1,0 +1,27 @@
+﻿using Ardalis.Specification.QueryExtensions.Include;
+using Ardalis.Specification.UnitTests.QueryExtensions.Include.Entities;
+using System.Collections.Generic;
+
+namespace Ardalis.Specification.UnitTests.QueryExtensions.Include.Builders
+{
+    class IncludeQueryBuilder
+    {
+        public IncludeQuery<Person, List<Person>> WithCollectionAsPreviousProperty()
+        {
+            var pathMap = new Dictionary<IIncludeQuery, string>();
+            var query = new IncludeQuery<Person, List<Person>>(pathMap);
+            pathMap[query] = nameof(Person.Friends);
+
+            return query;
+        }
+
+        public IncludeQuery<Book, Person> WithObjectAsPreviousProperty()
+        {
+            var pathMap = new Dictionary<IIncludeQuery, string>();
+            var query = new IncludeQuery<Book, Person>(pathMap);
+            pathMap[query] = nameof(Book.Author);
+
+            return query;
+        }
+    }
+}

--- a/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/Entities/Book.cs
+++ b/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/Entities/Book.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Ardalis.Specification.UnitTests.QueryExtensions.Include.Entities
+{
+    class Book
+    {
+        public string Title { get; set; }
+        public DateTime PublishingDate { get; set; }
+        public Person Author { get; set; }
+
+        public int GetNumberOfSales()
+        {
+            return 0;
+        }
+    }
+}

--- a/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/Entities/Person.cs
+++ b/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/Entities/Person.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ardalis.Specification.UnitTests.QueryExtensions.Include.Entities
+{
+    class Person
+    {
+        public int Age { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+
+        public Book FavouriteBook { get; set; }
+        public List<Person> Friends { get; set; }
+
+        public string GetQuote()
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeAggregatorTests.cs
+++ b/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeAggregatorTests.cs
@@ -22,10 +22,11 @@ namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
         {
             var includeAggregator = new IncludeAggregator<Person>();
 
-            // This include does not make much sense, but it should at least do not modify the paths.
+            // This include does not make much sense, but it should at least not modify the paths.
             var includeQuery = includeAggregator.Include(p => p.FavouriteBook.GetNumberOfSales());
 
-            Assert.Contains(includeQuery.Paths, path => path == nameof(Person.FavouriteBook));
+            // The resulting paths should not include number of sales.
+            Assert.DoesNotContain(includeQuery.Paths, path => path == nameof(Book.GetNumberOfSales));
         }
 
         [Fact]

--- a/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeAggregatorTests.cs
+++ b/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeAggregatorTests.cs
@@ -1,0 +1,49 @@
+﻿using Ardalis.Specification.QueryExtensions.Include;
+using Ardalis.Specification.UnitTests.QueryExtensions.Include.Entities;
+using Xunit;
+
+namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
+{
+    public class IncludeAggregatorTests
+    {
+        [Fact]
+        public void Include_SimpleType_ReturnsIncludeQueryWithCorrectPath()
+        {
+            var includeAggregator = new IncludeAggregator<Person>();
+
+            // There may be ORM libraries where including a simple type makes sense.
+            var includeQuery = includeAggregator.Include(p => p.Age);
+
+            Assert.Contains(includeQuery.Paths, path => path == nameof(Person.Age));
+        }
+
+        [Fact]
+        public void Include_Function_ReturnsIncludeQueryWithCorrectPath()
+        {
+            var includeAggregator = new IncludeAggregator<Person>();
+
+            // This include does not make much sense, but it should at least do not modify the paths.
+            var includeQuery = includeAggregator.Include(p => p.FavouriteBook.GetNumberOfSales());
+
+            Assert.Contains(includeQuery.Paths, path => path == nameof(Person.FavouriteBook));
+        }
+
+        [Fact]
+        public void Include_Object_ReturnsIncludeQueryWithCorrectPath()
+        {
+            var includeAggregator = new IncludeAggregator<Person>();
+            var includeQuery = includeAggregator.Include(p => p.FavouriteBook.Author);
+
+            Assert.Contains(includeQuery.Paths, path => path == $"{nameof(Person.FavouriteBook)}.{nameof(Book.Author)}");
+        }
+
+        [Fact]
+        public void Include_Collection_ReturnsIncludeQueryWithCorrectPath()
+        {
+            var includeAggregator = new IncludeAggregator<Book>();
+            var includeQuery = includeAggregator.Include(o => o.Author.Friends);
+
+            Assert.Contains(includeQuery.Paths, path => path == $"{nameof(Book.Author)}.{nameof(Person.Friends)}");
+        }
+    }
+}

--- a/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeQueryTests.cs
+++ b/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeQueryTests.cs
@@ -1,0 +1,160 @@
+﻿using Ardalis.Specification.QueryExtensions.Include;
+using Ardalis.Specification.UnitTests.QueryExtensions.Include.Builders;
+using Ardalis.Specification.UnitTests.QueryExtensions.Include.Entities;
+using System.Linq;
+using Xunit;
+
+namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
+{
+    public class IncludeQueryTests
+    {
+        private IncludeQueryBuilder _includeQueryBuilder = new IncludeQueryBuilder();
+
+        [Fact]
+        public void Include_SimpleType_ReturnsIncludeQueryWithCorrectPath()
+        {
+            var includeQuery = _includeQueryBuilder.WithObjectAsPreviousProperty();
+
+            // There may be ORM libraries where including a simple type makes sense.
+            var newIncludeQuery = includeQuery.Include(b => b.Title);
+
+            Assert.Contains(newIncludeQuery.Paths, path => path == nameof(Book.Title));
+        }
+
+        [Fact]
+        public void Include_Function_ReturnsIncludeQueryWithCorrectPath()
+        {
+            var includeQuery = _includeQueryBuilder.WithObjectAsPreviousProperty();
+
+            // This include does not make much sense, but it should at least do not modify paths.
+            var newIncludeQuery = includeQuery.Include(b => b.GetNumberOfSales());
+
+            // The resulting paths should not include number of sales.
+            Assert.DoesNotContain(newIncludeQuery.Paths, path => path == nameof(Book.GetNumberOfSales));
+        }
+
+        [Fact]
+        public void Include_Object_ReturnsIncludeQueryWithCorrectPath()
+        {
+            var includeQuery = _includeQueryBuilder.WithObjectAsPreviousProperty();
+            var newIncludeQuery = includeQuery.Include(b => b.Author);
+
+            Assert.Contains(newIncludeQuery.Paths, path => path == nameof(Book.Author));
+        }
+
+        [Fact]
+        public void Include_Collection_ReturnsIncludeQueryWithCorrectPath()
+        {
+            var includeQuery = _includeQueryBuilder.WithObjectAsPreviousProperty();
+
+            var newIncludeQuery = includeQuery.Include(b => b.Author.Friends);
+            var expectedPath = $"{nameof(Book.Author)}.{nameof(Person.Friends)}";
+
+            Assert.Contains(newIncludeQuery.Paths, path => path == expectedPath);
+        }
+
+        [Fact]
+        public void Include_IncreasesNumberOfPathsByOne()
+        {
+            var includeQuery = _includeQueryBuilder.WithObjectAsPreviousProperty();
+            var numberOfPathsBeforeInclude = includeQuery.Paths.Count;
+
+            var newIncludeQuery = includeQuery.Include(b => b.Author.Friends);
+            var numberOfPathsAferInclude = newIncludeQuery.Paths.Count;
+
+            var expectedNumerOfPaths = numberOfPathsBeforeInclude + 1;
+
+            Assert.Equal(expectedNumerOfPaths, numberOfPathsAferInclude);
+        }
+
+        [Fact]
+        public void Include_DoesNotModifyAnotherPath()
+        {
+            var includeQuery = _includeQueryBuilder.WithObjectAsPreviousProperty();
+            var pathsBeforeInclude = includeQuery.Paths;
+
+            var newIncludeQuery = includeQuery.Include(b => b.Author.Friends);
+            var pathsAfterInclude = newIncludeQuery.Paths;
+
+            Assert.Subset(pathsAfterInclude, pathsBeforeInclude);
+        }
+
+        [Fact]
+        public void ThenInclude_SimpleType_ReturnsIncludeQueryWithCorrectPath()
+        {
+            var includeQuery = _includeQueryBuilder.WithObjectAsPreviousProperty();
+            var pathBeforeInclude = includeQuery.Paths.First();
+
+            // There may be ORM libraries where including a simple type makes sense.
+            var newIncludeQuery = includeQuery.ThenInclude(p => p.Age);
+            var pathAfterInclude = newIncludeQuery.Paths.First();
+            var expectedPath = $"{pathBeforeInclude}.{nameof(Person.Age)}";
+
+            Assert.Equal(expectedPath, pathAfterInclude);
+        }
+
+        [Fact]
+        public void ThenInclude_Function_ReturnsIncludeQueryWithCorrectPath()
+        {
+            var includeQuery = _includeQueryBuilder.WithObjectAsPreviousProperty();
+            var pathBeforeInclude = includeQuery.Paths.First();
+
+            // This include does not make much sense, but it should at least not modify the paths.
+            var newIncludeQuery = includeQuery.ThenInclude(p => p.GetQuote());
+            var pathAfterInclude = newIncludeQuery.Paths.First();
+
+            Assert.Equal(pathBeforeInclude, pathAfterInclude);
+        }
+
+        [Fact]
+        public void ThenInclude_Object_ReturnsIncludeQueryWithCorrectPath()
+        {
+            var includeQuery = _includeQueryBuilder.WithObjectAsPreviousProperty();
+            var pathBeforeInclude = includeQuery.Paths.First();
+
+            var newIncludeQuery = includeQuery.ThenInclude(p => p.FavouriteBook);
+            var pathAfterInclude = newIncludeQuery.Paths.First();
+            var expectedPath = $"{pathBeforeInclude}.{nameof(Person.FavouriteBook)}";
+
+            Assert.Equal(expectedPath, pathAfterInclude);
+        }
+
+        [Fact]
+        public void ThenInclude_Collection_ReturnsIncludeQueryWithCorrectPath()
+        {
+            var includeQuery = _includeQueryBuilder.WithObjectAsPreviousProperty();
+            var pathBeforeInclude = includeQuery.Paths.First();
+
+            var newIncludeQuery = includeQuery.ThenInclude(p => p.Friends);
+            var pathAfterInclude = newIncludeQuery.Paths.First();
+            var expectedPath = $"{pathBeforeInclude}.{nameof(Person.Friends)}";
+
+            Assert.Equal(expectedPath, pathAfterInclude);
+        }
+
+        [Fact]
+        public void ThenInclude_PropertyOverCollection_ReturnsIncludeQueryWithCorrectPath()
+        {
+            var includeQuery = _includeQueryBuilder.WithCollectionAsPreviousProperty();
+            var pathBeforeInclude = includeQuery.Paths.First();
+
+            var newIncludeQuery = includeQuery.ThenInclude(p => p.FavouriteBook);
+            var pathAfterInclude = newIncludeQuery.Paths.First();
+            var expectedPath = $"{pathBeforeInclude}.{nameof(Person.FavouriteBook)}";
+
+            Assert.Equal(expectedPath, pathAfterInclude);
+        }
+
+        [Fact]
+        public void ThenInclude_FunctionOverCollection_ReturnsIncludeQueryWithCorrectPath()
+        {
+            var includeQuery = _includeQueryBuilder.WithCollectionAsPreviousProperty();
+            var pathBeforeInclude = includeQuery.Paths.First();
+
+            var newIncludeQuery = includeQuery.ThenInclude(p => p.GetQuote());
+            var pathAfterInclude = newIncludeQuery.Paths.First();
+
+            Assert.Equal(pathBeforeInclude, pathAfterInclude);
+        }
+    }
+}

--- a/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeQueryTests.cs
+++ b/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeQueryTests.cs
@@ -26,7 +26,7 @@ namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
         {
             var includeQuery = _includeQueryBuilder.WithObjectAsPreviousProperty();
 
-            // This include does not make much sense, but it should at least do not modify paths.
+            // This include does not make much sense, but it should at least not modify paths.
             var newIncludeQuery = includeQuery.Include(b => b.GetNumberOfSales());
 
             // The resulting paths should not include number of sales.

--- a/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeVisitorTests.cs
+++ b/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeVisitorTests.cs
@@ -1,0 +1,56 @@
+﻿using Ardalis.Specification.QueryExtensions.Include;
+using Ardalis.Specification.UnitTests.QueryExtensions.Include.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
+{
+    public class IncludeVisitorTests
+    {
+        [Fact]
+        public void Visit_ExpressionWithSimpleType_ShouldSetCorrectPath()
+        {
+            var visitor = new IncludeVisitor();
+            Expression<Func<Book, string>> expression = (book) => book.Author.FirstName;
+            visitor.Visit(expression);
+
+            var expectedPath = $"{nameof(Book.Author)}.{nameof(Person.FirstName)}";
+            Assert.Equal(expectedPath, visitor.Path);
+        }
+
+        [Fact]
+        public void Visit_ExpressionWithObject_ShouldSetCorrectPath()
+        {
+            var visitor = new IncludeVisitor();
+            Expression<Func<Book, Book>> expression = (book) => book.Author.FavouriteBook;
+            visitor.Visit(expression);
+
+            var expectedPath = $"{nameof(Book.Author)}.{nameof(Person.FavouriteBook)}";
+            Assert.Equal(expectedPath, visitor.Path);
+        }
+
+        [Fact]
+        public void Visit_ExpressionWithCollection_ShouldSetCorrectPath()
+        {
+            var visitor = new IncludeVisitor();
+            Expression<Func<Book, List<Person>>> expression = (book) => book.Author.Friends;
+            visitor.Visit(expression);
+
+            var expectedPath = $"{nameof(Book.Author)}.{nameof(Person.Friends)}";
+            Assert.Equal(expectedPath, visitor.Path);
+        }
+
+        [Fact]
+        public void Visit_ExpressionWithFunction_ShouldSetCorrectPath()
+        {
+            var visitor = new IncludeVisitor();
+            Expression<Func<Book, string>> expression = (book) => book.Author.GetQuote();
+            visitor.Visit(expression);
+
+            var expectedPath = nameof(Book.Author);
+            Assert.Equal(expectedPath, visitor.Path);
+        }
+    }
+}


### PR DESCRIPTION
I added the possibility to use .Include followed by .ThenInclude. This should make it easier to define what properties should be loaded.
Chainable Includes add their paths to the existing IncludeStrings, because i think the most generic approach to define proprties to load are strings.