### PR TITLE
Consolidating the selector functionality.

### DIFF
--- a/src/Ardalis.Specification/BaseSpecification.cs
+++ b/src/Ardalis.Specification/BaseSpecification.cs
@@ -7,8 +7,6 @@ using System.Linq.Expressions;
 
 namespace Ardalis.Specification
 {
-    // Keeping both classes here for clarity. Will fix it afterward
-
     public abstract class BaseSpecification<T, TResult> : BaseSpecification<T>, ISpecification<T, TResult>
     {
         protected BaseSpecification(Expression<Func<T, bool>> criteria) : base(criteria) { }
@@ -44,6 +42,7 @@ namespace Ardalis.Specification
         {
             ((List<Expression<Func<T, bool>>>)Criterias).Add(criteria);
         }
+
         protected virtual void AddInclude(Expression<Func<T, object>> includeExpression)
         {
             ((List<Expression<Func<T, object>>>)Includes).Add(includeExpression);
@@ -91,10 +90,7 @@ namespace Ardalis.Specification
         protected void EnableCache(string specificationName, params object[] args)
         {
             Guard.Against.NullOrEmpty(specificationName, nameof(specificationName));
-
-            // Just to be able to throw exception if the list is empty. "Guard.Against.EmptyList" might be nice extension for GuardClauses.
-            var criteria = Criterias.FirstOrDefault();
-            Guard.Against.Null(criteria, nameof(criteria));
+            Guard.Against.NullOrEmpty(Criterias, nameof(Criterias));
 
             CacheKey = $"{specificationName}-{string.Join("-", args)}";
 

--- a/src/Ardalis.Specification/EfSpecificationEvaluator.cs
+++ b/src/Ardalis.Specification/EfSpecificationEvaluator.cs
@@ -3,6 +3,19 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Ardalis.Specification
 {
+    public class EfSpecificationEvaluator<T, TId, TResult> where T : class, IEntity<TId>
+    {
+        public static IQueryable<TResult> GetQuery(IQueryable<T> inputQuery, ISpecification<T, TResult> specification)
+        {
+            var query = EfSpecificationEvaluator<T, TId>.GetQuery(inputQuery, specification);
+
+            // Apply selector
+            var selectQuery = query.Select(specification.Selector);
+
+            return selectQuery;
+        }
+    }
+
     public class EfSpecificationEvaluator<T, TId> where T : class, IEntity<TId>
     {
         public static IQueryable<T> GetQuery(IQueryable<T> inputQuery, ISpecification<T> specification)

--- a/tests/Ardalis.Specification.IntegrationTests/DatabaseCommunicationTestBase.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/DatabaseCommunicationTestBase.cs
@@ -1,0 +1,33 @@
+﻿using Ardalis.Specification.IntegrationTests.SampleClient;
+using Microsoft.EntityFrameworkCore;
+
+
+namespace Ardalis.Specification.IntegrationTests
+{
+    public class DatabaseCommunicationTestBase
+    {
+        // Run EF Migrations\DBUp script to prepare database before running your tests.
+        public const string ConnectionString = "Data Source=database;Initial Catalog=SampleDatabase;PersistSecurityInfo=True;User ID=sa;Password=P@ssW0rd!";
+        public SampleDbContext _dbContext;
+        public EfRepository<Blog> _blogRepository;
+        public EfRepository<Post> _postRepository;
+
+        public DatabaseCommunicationTestBase()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<SampleDbContext>();
+            optionsBuilder.UseSqlServer(ConnectionString);
+            _dbContext = new SampleDbContext(optionsBuilder.Options);
+
+            // Run this if you've made seed data or schema changes to force the container to rebuild the db
+            // _dbContext.Database.EnsureDeleted();
+
+            // Note: If the database exists, this will do nothing, so it only creates it once.
+            // This is fine since these tests all perform read-only operations
+            _dbContext.Database.EnsureCreated();
+
+            _blogRepository = new EfRepository<Blog>(_dbContext);
+            _postRepository = new EfRepository<Post>(_dbContext);
+        }
+
+    }
+}

--- a/tests/Ardalis.Specification.IntegrationTests/DatabaseCommunicationTests.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/DatabaseCommunicationTests.cs
@@ -11,31 +11,8 @@ using Xunit;
 
 namespace Ardalis.Specification.IntegrationTests
 {
-    public class DatabaseCommunicationTests
+    public class DatabaseCommunicationTests : DatabaseCommunicationTestBase
     {
-        // Run EF Migrations\DBUp script to prepare database before running your tests.
-        const string ConnectionString = "Data Source=database;Initial Catalog=SampleDatabase;PersistSecurityInfo=True;User ID=sa;Password=P@ssW0rd!";
-        public SampleDbContext _dbContext;
-        public EfRepository<Blog> _blogRepository;
-        public EfRepository<Post> _postRepository;
-
-        public DatabaseCommunicationTests()
-        {
-            var optionsBuilder = new DbContextOptionsBuilder<SampleDbContext>();
-            optionsBuilder.UseSqlServer(ConnectionString);
-            _dbContext = new SampleDbContext(optionsBuilder.Options);
-
-            // Run this if you've made seed data or schema changes to force the container to rebuild the db
-            // _dbContext.Database.EnsureDeleted();
-
-            // Note: If the database exists, this will do nothing, so it only creates it once.
-            // This is fine since these tests all perform read-only operations
-            _dbContext.Database.EnsureCreated();
-
-            _blogRepository = new EfRepository<Blog>(_dbContext);
-            _postRepository = new EfRepository<Post>(_dbContext);
-        }
-
         [Fact]
         public async Task CanConnectAndRunQuery()
         {
@@ -51,7 +28,7 @@ namespace Ardalis.Specification.IntegrationTests
         [Fact]
         public async Task GetBlogUsingEF()
         {
-            var result = _dbContext.Blogs.FirstOrDefault();
+            var result = await _dbContext.Blogs.FirstOrDefaultAsync();
 
             Assert.Equal(BlogBuilder.VALID_BLOG_ID, result.Id);
         }
@@ -129,7 +106,7 @@ namespace Ardalis.Specification.IntegrationTests
 
         // TODO: This could move to the Unit Tests project if specs were in separate project
         [Fact]
-        public async Task EnableCacheShouldSetCacheKeyProperly()
+        public void EnableCacheShouldSetCacheKeyProperly()
         {
             var spec = new BlogWithPostsSpec(BlogBuilder.VALID_BLOG_ID);
 

--- a/tests/Ardalis.Specification.IntegrationTests/SampleClient/EfRepository.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleClient/EfRepository.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using System.Linq;
 using System.Threading.Tasks;
+using System;
 
 namespace Ardalis.Specification.IntegrationTests.SampleClient
 {
@@ -34,6 +35,16 @@ namespace Ardalis.Specification.IntegrationTests.SampleClient
             return await ApplySpecification(spec).ToListAsync();
         }
 
+        public async Task<IReadOnlyList<TResult>> ListAsync<TResult>(ISpecification<T, TResult> spec)
+        {
+            {
+                if (spec is null) throw new ArgumentNullException("spec is required");
+                if (spec.Selector is null) throw new Exception("Specification must have Selector defined.");
+
+                return await ApplySpecification(spec).ToListAsync();
+            }
+        }
+
         public async Task<int> CountAsync(ISpecification<T> spec)
         {
             return await ApplySpecification(spec).CountAsync();
@@ -62,6 +73,11 @@ namespace Ardalis.Specification.IntegrationTests.SampleClient
         private IQueryable<T> ApplySpecification(ISpecification<T> spec)
         {
             return EfSpecificationEvaluator<T, int>.GetQuery(_dbContext.Set<T>().AsQueryable(), spec);
+        }
+
+        private IQueryable<TResult> ApplySpecification<TResult>(ISpecification<T, TResult> spec)
+        {
+            return EfSpecificationEvaluator<T, int, TResult>.GetQuery(_dbContext.Set<T>().AsQueryable(), spec);
         }
     }
 }

--- a/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/BlogNamesSpecification.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/BlogNamesSpecification.cs
@@ -1,0 +1,14 @@
+﻿using Ardalis.Specification.IntegrationTests.SampleClient;
+
+namespace Ardalis.Specification.IntegrationTests.SampleSpecs
+{
+    // We are selecting/returning b.Name (string property), so we define the TResult generic parameter as string.
+    // It's the only place where this generic parameter is defined, everywhere else will be implicitly inferred.
+    public class BlogNamesSpecification : BaseSpecification<Blog, string>
+    {
+        public BlogNamesSpecification() : base(b => true)
+        {
+            Selector = b => b.Name;
+        }
+    }
+}

--- a/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/PostSelectSpecification.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/PostSelectSpecification.cs
@@ -1,0 +1,18 @@
+﻿using Ardalis.Specification.IntegrationTests.SampleClient;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace Ardalis.Specification.IntegrationTests.SampleSpecs
+{
+    // Just an example where selector expression is passed as an argument.
+    // Since it's generic solution, we should be cautious in its usage.
+    public class PostSelectSpecification : BaseSpecification<Post, object>
+    {
+        public PostSelectSpecification(Expression<Func<Post, object>> selector) : base(b => true)
+        {
+            Selector = selector;
+        }
+    }
+}

--- a/tests/Ardalis.Specification.IntegrationTests/SelectorTests.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SelectorTests.cs
@@ -1,0 +1,46 @@
+﻿using Ardalis.Specification.IntegrationTests.SampleClient;
+using Ardalis.Specification.IntegrationTests.SampleSpecs;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Ardalis.Specification.IntegrationTests
+{
+    public class SelectorTests : DatabaseCommunicationTestBase
+    {
+        [Fact]
+        public async Task GetBlogsSelectNameOnlyReturnsStringWithNameUsingDbContext()
+        {
+            var result = await _dbContext.Blogs.Select(new BlogNamesSpecification().Selector)
+                                                .FirstOrDefaultAsync();
+
+            result.Should().NotBeNull();
+            result.Should().Be(BlogBuilder.VALID_BLOG_NAME);
+        }
+
+        [Fact]
+        public async Task GetBlogsSelectNameOnlyReturnsStringWithNameUsingEfRepository()
+        {
+            var spec = new BlogNamesSpecification();
+            var result = (await _blogRepository.ListAsync(spec))
+                .FirstOrDefault();
+
+            result.Should().NotBeNull();
+            result.Should().Be(BlogBuilder.VALID_BLOG_NAME);
+        }
+
+        [Fact]
+        public async Task GetPostsSelectNameAndContentOnlyReturnsExpectedResultsUsingEfRepository()
+        {
+            var spec = new PostSelectSpecification(p => new { p.Title, p.Content });
+            dynamic result = (await _postRepository.ListAsync(spec))
+                .FirstOrDefault();
+
+            Assert.NotNull(result);
+            Assert.Equal("First post!", result.Title);
+            Assert.Equal("Lorem ipsum", result.Content);
+        }
+    }
+}


### PR DESCRIPTION
Hi @ardalis 

I added the missing parts and the integration tests for the selector.

Let me describe shortly the functionality:

- The intention was not only adding the selector functionality in the specification, but also keeping the evaluation of the same within the specification (not delegating it out to the EFRepository).
- Select always returns new type. That's why need new inherited infrastructure containing the output type.
- Adding new List method in EFRepository would just confuse the users. Therefore, the method is overloaded, and based on the fact if specification contains a selector or not, the appropriate method will be utilized.