### PR TITLE
Enable nullable reference types

### DIFF
--- a/src/Ardalis.Specification/Ardalis.Specification.csproj
+++ b/src/Ardalis.Specification/Ardalis.Specification.csproj
@@ -19,7 +19,8 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="1.5.0" />

--- a/src/Ardalis.Specification/BaseSpecification.cs
+++ b/src/Ardalis.Specification/BaseSpecification.cs
@@ -10,7 +10,7 @@ namespace Ardalis.Specification
     {
         protected BaseSpecification(Expression<Func<T, bool>> criteria) : base(criteria) { }
 
-        public Expression<Func<T, TResult>> Selector { get; set; }
+        public Expression<Func<T, TResult>>? Selector { get; set; }
     }
 
     public abstract class BaseSpecification<T> : ISpecification<T>
@@ -27,16 +27,16 @@ namespace Ardalis.Specification
         public IEnumerable<Expression<Func<T, object>>> Includes { get; } = new List<Expression<Func<T, object>>>();
         public IEnumerable<string> IncludeStrings { get; } = new List<string>();
 
-        public Expression<Func<T, object>> ThenBy { get; private set; }
-        public Expression<Func<T, object>> OrderBy { get; private set; }
-        public Expression<Func<T, object>> OrderByDescending { get; private set; }
+        public Expression<Func<T, object>>? ThenBy { get; private set; }
+        public Expression<Func<T, object>>? OrderBy { get; private set; }
+        public Expression<Func<T, object>>? OrderByDescending { get; private set; }
         //public Expression<Func<T, object>> GroupBy { get; private set; }
 
         public int Take { get; private set; }
         public int Skip { get; private set; }
         public bool IsPagingEnabled { get; private set; } = false;
 
-        public string CacheKey { get; protected set; }
+        public string? CacheKey { get; protected set; }
         public bool CacheEnabled { get; private set; }
 
         protected virtual void AddCriteria(Expression<Func<T, bool>> criteria)

--- a/src/Ardalis.Specification/EfSpecificationEvaluator.cs
+++ b/src/Ardalis.Specification/EfSpecificationEvaluator.cs
@@ -6,9 +6,9 @@ namespace Ardalis.Specification
 {
     public class EfSpecificationEvaluator<T, TResult> where T : class
     {
-        public static async Task<IQueryable<TResult>> GetQuery(IQueryable<T> inputQuery, ISpecification<T, TResult> specification)
+        public static IQueryable<TResult> GetQuery(IQueryable<T> inputQuery, ISpecification<T, TResult> specification)
         {
-            var query = await EfSpecificationEvaluator<T>.GetQuery(inputQuery, specification);
+            var query = EfSpecificationEvaluator<T>.GetQuery(inputQuery, specification);
 
             // Apply selector
             var selectQuery = query.Select(specification.Selector);
@@ -19,11 +19,11 @@ namespace Ardalis.Specification
 
     public class EfSpecificationEvaluator<T> where T : class
     {
-        public static async Task<IQueryable<T>> GetQuery(IQueryable<T> inputQuery, ISpecification<T> specification)
+        public static IQueryable<T> GetQuery(IQueryable<T> inputQuery, ISpecification<T> specification)
         {
             var query = inputQuery;
 
-            query = await SpecificationEvaluator<T>.GetQuery(query, specification);
+            query = SpecificationEvaluator<T>.GetQuery(query, specification);
 
             // Includes all expression-based includes
             query = specification.Includes.Aggregate(query,

--- a/src/Ardalis.Specification/ISpecification.cs
+++ b/src/Ardalis.Specification/ISpecification.cs
@@ -6,21 +6,21 @@ namespace Ardalis.Specification
 {
     public interface ISpecification<T, TResult> : ISpecification<T>
     {
-        Expression<Func<T, TResult>> Selector { get; set; }
+        Expression<Func<T, TResult>>? Selector { get; set; }
     }
 
     public interface ISpecification<T>
     {
         bool CacheEnabled { get; }
-        string CacheKey { get; }
+        string? CacheKey { get; }
 
         IEnumerable<Expression<Func<T, bool>>> Criterias { get; }
         IEnumerable<Expression<Func<T, object>>> Includes { get; }
         IEnumerable<string> IncludeStrings { get; }
 
-        Expression<Func<T, object>> OrderBy { get; }
-        Expression<Func<T, object>> ThenBy { get; }
-        Expression<Func<T, object>> OrderByDescending { get; }
+        Expression<Func<T, object>>? OrderBy { get; }
+        Expression<Func<T, object>>? ThenBy { get; }
+        Expression<Func<T, object>>? OrderByDescending { get; }
         //Expression<Func<T, object>> GroupBy { get; }
 
         int Take { get; }

--- a/src/Ardalis.Specification/SpecificationEvaluator.cs
+++ b/src/Ardalis.Specification/SpecificationEvaluator.cs
@@ -1,12 +1,11 @@
-﻿using Microsoft.EntityFrameworkCore;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 
 namespace Ardalis.Specification
 {
     public class SpecificationEvaluator<T> where T : class
     {
-        public static async Task<IQueryable<T>> GetQuery(IQueryable<T> inputQuery, ISpecification<T> specification)
+        public static Task<IQueryable<T>> GetQuery(IQueryable<T> inputQuery, ISpecification<T> specification)
         {
             var query = inputQuery;
 
@@ -47,7 +46,7 @@ namespace Ardalis.Specification
                 query = query.Skip(specification.Skip)
                              .Take(specification.Take);
             }
-            return query;
+            return Task.FromResult(query);
         }
     }
 }

--- a/src/Ardalis.Specification/SpecificationEvaluator.cs
+++ b/src/Ardalis.Specification/SpecificationEvaluator.cs
@@ -5,7 +5,7 @@ namespace Ardalis.Specification
 {
     public class SpecificationEvaluator<T> where T : class
     {
-        public static Task<IQueryable<T>> GetQuery(IQueryable<T> inputQuery, ISpecification<T> specification)
+        public static IQueryable<T> GetQuery(IQueryable<T> inputQuery, ISpecification<T> specification)
         {
             var query = inputQuery;
 
@@ -46,7 +46,8 @@ namespace Ardalis.Specification
                 query = query.Skip(specification.Skip)
                              .Take(specification.Take);
             }
-            return Task.FromResult(query);
+
+            return query;
         }
     }
 }

--- a/tests/Ardalis.Specification.IntegrationTests/Ardalis.Specification.IntegrationTests.csproj
+++ b/tests/Ardalis.Specification.IntegrationTests/Ardalis.Specification.IntegrationTests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Ardalis.Specification.IntegrationTests/SampleClient/Author.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleClient/Author.cs
@@ -5,8 +5,8 @@ namespace Ardalis.Specification.IntegrationTests.SampleClient
     public class Author : IEntity<int>
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public string Email { get; set; }
+        public string? Name { get; set; }
+        public string? Email { get; set; }
         public ICollection<Post> Posts { get; set; } = new List<Post>();
     }
 }

--- a/tests/Ardalis.Specification.IntegrationTests/SampleClient/Blog.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleClient/Blog.cs
@@ -5,8 +5,8 @@ namespace Ardalis.Specification.IntegrationTests.SampleClient
     public class Blog : IEntity<int>
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public string Url { get; set; }
+        public string? Name { get; set; }
+        public string? Url { get; set; }
         public ICollection<Post> Posts { get; set; } = new List<Post>();
     }
 }

--- a/tests/Ardalis.Specification.IntegrationTests/SampleClient/EfRepository.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleClient/EfRepository.cs
@@ -72,12 +72,12 @@ namespace Ardalis.Specification.IntegrationTests.SampleClient
 
         private IQueryable<T> ApplySpecification(ISpecification<T> spec)
         {
-            return EfSpecificationEvaluator<T>.GetQuery(_dbContext.Set<T>().AsQueryable(), spec).Result;
+            return EfSpecificationEvaluator<T>.GetQuery(_dbContext.Set<T>().AsQueryable(), spec);
         }
 
         private IQueryable<TResult> ApplySpecification<TResult>(ISpecification<T, TResult> spec)
         {
-            return EfSpecificationEvaluator<T, TResult>.GetQuery(_dbContext.Set<T>().AsQueryable(), spec).Result;
+            return EfSpecificationEvaluator<T, TResult>.GetQuery(_dbContext.Set<T>().AsQueryable(), spec);
         }
     }
 }

--- a/tests/Ardalis.Specification.IntegrationTests/SampleClient/Post.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleClient/Post.cs
@@ -6,9 +6,9 @@
         public int BlogId { get; set; }
         public int AuthorId { get; set; }
 
-        public string Content { get; set; }
-        public string Title { get; set; }
+        public string? Content { get; set; }
+        public string? Title { get; set; }
 
-        public Author Author { get; set; }
+        public Author? Author { get; set; }
     }
 }

--- a/tests/Ardalis.Specification.IntegrationTests/SampleClient/SampleDbContext.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleClient/SampleDbContext.cs
@@ -12,12 +12,13 @@ namespace Ardalis.Specification.IntegrationTests.SampleClient
             builder.AddConsole();
         });
 
-        public DbSet<Author> Authors { get; set; }
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+        public DbSet<Author>? Authors { get; set; }
+        public DbSet<Blog>? Blogs { get; set; }
+        public DbSet<Post>? Posts { get; set; }
 
         public SampleDbContext(DbContextOptions options) : base(options)
         {
+            
         }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -37,8 +38,10 @@ namespace Ardalis.Specification.IntegrationTests.SampleClient
             var testBlog = blogBuilder.WithTestValues().Build();
             modelBuilder.Entity<Blog>().HasData(testBlog);
 
-            var postList = new List<Post>();
-            postList.Add(new Post { Id=234, AuthorId = author.Id, BlogId = testBlog.Id, Title = "First post!", Content = "Lorem ipsum" });
+            var postList = new List<Post>
+            {
+                new Post { Id = 234, AuthorId = author.Id, BlogId = testBlog.Id, Title = "First post!", Content = "Lorem ipsum" }
+            };
             for (int i = 0; i < 100; i++)
             {
                 postList.Add(new Post { AuthorId = author.Id, BlogId = testBlog.Id, Title = $"Extra post {i}", Id = 300 + i });

--- a/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/BlogNamesSpecification.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/BlogNamesSpecification.cs
@@ -8,7 +8,7 @@ namespace Ardalis.Specification.IntegrationTests.SampleSpecs
     {
         public BlogNamesSpecification() : base(b => true)
         {
-            Selector = b => b.Name;
+            Selector = b => b.Name!;
         }
     }
 }

--- a/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/PostsByBlogOrderedByThenBySpec.cs
+++ b/tests/Ardalis.Specification.IntegrationTests/SampleSpecs/PostsByBlogOrderedByThenBySpec.cs
@@ -9,11 +9,11 @@ namespace Ardalis.Specification.IntegrationTests.SampleSpecs
         {
             if(isAscending)
             {
-                ApplyOrderByWithThenBy(p => p.AuthorId, p => p.Title);
+                ApplyOrderByWithThenBy(p => p.AuthorId, p => p.Title!);
             }
             else
             {
-                ApplyOrderByDescendingWithThenBy(p => p.Id, p => p.Title);
+                ApplyOrderByDescendingWithThenBy(p => p.Id, p => p.Title!);
             }
         }
     }

--- a/tests/Ardalis.Specification.UnitTests/Ardalis.Specification.UnitTests.csproj
+++ b/tests/Ardalis.Specification.UnitTests/Ardalis.Specification.UnitTests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/Entities/Book.cs
+++ b/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/Entities/Book.cs
@@ -2,11 +2,11 @@
 
 namespace Ardalis.Specification.UnitTests.QueryExtensions.Include.Entities
 {
-    class Book
+    internal class Book
     {
-        public string Title { get; set; }
+        public string? Title { get; set; }
         public DateTime PublishingDate { get; set; }
-        public Person Author { get; set; }
+        public Person? Author { get; set; }
 
         public int GetNumberOfSales()
         {

--- a/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/Entities/Person.cs
+++ b/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/Entities/Person.cs
@@ -7,11 +7,11 @@ namespace Ardalis.Specification.UnitTests.QueryExtensions.Include.Entities
     class Person
     {
         public int Age { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
 
-        public Book FavouriteBook { get; set; }
-        public List<Person> Friends { get; set; }
+        public Book? FavouriteBook { get; set; }
+        public List<Person>? Friends { get; set; }
 
         public string GetQuote()
         {

--- a/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeAggregatorTests.cs
+++ b/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeAggregatorTests.cs
@@ -23,7 +23,7 @@ namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
             var includeAggregator = new IncludeAggregator<Person>();
 
             // This include does not make much sense, but it should at least not modify the paths.
-            var includeQuery = includeAggregator.Include(p => p.FavouriteBook.GetNumberOfSales());
+            var includeQuery = includeAggregator.Include(p => p.FavouriteBook!.GetNumberOfSales());
 
             // The resulting paths should not include number of sales.
             Assert.DoesNotContain(includeQuery.Paths, path => path == nameof(Book.GetNumberOfSales));
@@ -33,7 +33,7 @@ namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
         public void Include_Object_ReturnsIncludeQueryWithCorrectPath()
         {
             var includeAggregator = new IncludeAggregator<Person>();
-            var includeQuery = includeAggregator.Include(p => p.FavouriteBook.Author);
+            var includeQuery = includeAggregator.Include(p => p.FavouriteBook!.Author);
 
             Assert.Contains(includeQuery.Paths, path => path == $"{nameof(Person.FavouriteBook)}.{nameof(Book.Author)}");
         }
@@ -42,7 +42,7 @@ namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
         public void Include_Collection_ReturnsIncludeQueryWithCorrectPath()
         {
             var includeAggregator = new IncludeAggregator<Book>();
-            var includeQuery = includeAggregator.Include(o => o.Author.Friends);
+            var includeQuery = includeAggregator.Include(o => o.Author!.Friends);
 
             Assert.Contains(includeQuery.Paths, path => path == $"{nameof(Book.Author)}.{nameof(Person.Friends)}");
         }

--- a/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeQueryTests.cs
+++ b/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeQueryTests.cs
@@ -8,7 +8,7 @@ namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
 {
     public class IncludeQueryTests
     {
-        private IncludeQueryBuilder _includeQueryBuilder = new IncludeQueryBuilder();
+        private readonly IncludeQueryBuilder _includeQueryBuilder = new IncludeQueryBuilder();
 
         [Fact]
         public void Include_SimpleType_ReturnsIncludeQueryWithCorrectPath()
@@ -47,7 +47,7 @@ namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
         {
             var includeQuery = _includeQueryBuilder.WithObjectAsPreviousProperty();
 
-            var newIncludeQuery = includeQuery.Include(b => b.Author.Friends);
+            var newIncludeQuery = includeQuery.Include(b => b.Author!.Friends);
             var expectedPath = $"{nameof(Book.Author)}.{nameof(Person.Friends)}";
 
             Assert.Contains(newIncludeQuery.Paths, path => path == expectedPath);
@@ -59,7 +59,7 @@ namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
             var includeQuery = _includeQueryBuilder.WithObjectAsPreviousProperty();
             var numberOfPathsBeforeInclude = includeQuery.Paths.Count;
 
-            var newIncludeQuery = includeQuery.Include(b => b.Author.Friends);
+            var newIncludeQuery = includeQuery.Include(b => b.Author!.Friends);
             var numberOfPathsAferInclude = newIncludeQuery.Paths.Count;
 
             var expectedNumerOfPaths = numberOfPathsBeforeInclude + 1;
@@ -73,7 +73,7 @@ namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
             var includeQuery = _includeQueryBuilder.WithObjectAsPreviousProperty();
             var pathsBeforeInclude = includeQuery.Paths;
 
-            var newIncludeQuery = includeQuery.Include(b => b.Author.Friends);
+            var newIncludeQuery = includeQuery.Include(b => b.Author!.Friends);
             var pathsAfterInclude = newIncludeQuery.Paths;
 
             Assert.Subset(pathsAfterInclude, pathsBeforeInclude);

--- a/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeVisitorTests.cs
+++ b/tests/Ardalis.Specification.UnitTests/QueryExtensions/Include/IncludeVisitorTests.cs
@@ -13,7 +13,7 @@ namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
         public void Visit_ExpressionWithSimpleType_ShouldSetCorrectPath()
         {
             var visitor = new IncludeVisitor();
-            Expression<Func<Book, string>> expression = (book) => book.Author.FirstName;
+            Expression<Func<Book, string>> expression = (book) => book.Author!.FirstName!;
             visitor.Visit(expression);
 
             var expectedPath = $"{nameof(Book.Author)}.{nameof(Person.FirstName)}";
@@ -24,7 +24,7 @@ namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
         public void Visit_ExpressionWithObject_ShouldSetCorrectPath()
         {
             var visitor = new IncludeVisitor();
-            Expression<Func<Book, Book>> expression = (book) => book.Author.FavouriteBook;
+            Expression<Func<Book, Book>> expression = (book) => book.Author!.FavouriteBook!;
             visitor.Visit(expression);
 
             var expectedPath = $"{nameof(Book.Author)}.{nameof(Person.FavouriteBook)}";
@@ -35,7 +35,7 @@ namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
         public void Visit_ExpressionWithCollection_ShouldSetCorrectPath()
         {
             var visitor = new IncludeVisitor();
-            Expression<Func<Book, List<Person>>> expression = (book) => book.Author.Friends;
+            Expression<Func<Book, List<Person>>> expression = (book) => book.Author!.Friends!;
             visitor.Visit(expression);
 
             var expectedPath = $"{nameof(Book.Author)}.{nameof(Person.Friends)}";
@@ -46,7 +46,7 @@ namespace Ardalis.Specification.UnitTests.QueryExtensions.Include
         public void Visit_ExpressionWithFunction_ShouldSetCorrectPath()
         {
             var visitor = new IncludeVisitor();
-            Expression<Func<Book, string>> expression = (book) => book.Author.GetQuote();
+            Expression<Func<Book, string>> expression = (book) => book.Author!.GetQuote();
             visitor.Visit(expression);
 
             var expectedPath = nameof(Book.Author);

--- a/tests/Ardalis.Specification.UnitTests/SpecificationImplementationEvaluatorGetQuery.cs
+++ b/tests/Ardalis.Specification.UnitTests/SpecificationImplementationEvaluatorGetQuery.cs
@@ -21,11 +21,11 @@ namespace Ardalis.Specification.UnitTests
         }
 
         [Fact]
-        public async Task ReturnsEntityWithId()
+        public void ReturnsEntityWithId()
         {
             var spec = new ItemWithIdSpecification(_testId);
 
-            var result = await SpecificationEvaluator<TestItem>.GetQuery(
+            var result = SpecificationEvaluator<TestItem>.GetQuery(
                 GetTestListOfItems()
                     .AsQueryable(), 
                 spec);


### PR DESCRIPTION
Enable C# 8.0 Nullable Reference Types for the following projects
1)  Ardalis.Specification
2)  Ardalis.Specification.IntegrationTests
3)  Ardalis.Specification.UnitTests

Locally I tested both unit test and integration test and looks like all test passed successfully!

![image](https://user-images.githubusercontent.com/554039/84145871-4cd44a80-aa78-11ea-8c2a-ae84a115e14f.png)

@ardalis  Please take a look.