### PR TITLE
Internal builder refactoring. Chaining improvements.

### DIFF
--- a/ArdalisSpecification/src/Ardalis.Specification/Builder/IIncludableSpecificationBuilder.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Builder/IIncludableSpecificationBuilder.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Ardalis.Specification
 {
-    public interface IIncludableSpecificationBuilder<T, out TProperty>
+    public interface IIncludableSpecificationBuilder<T, out TProperty> : ISpecificationBuilder<T>
     {
         IIncludeAggregator Aggregator { get; }
     }

--- a/ArdalisSpecification/src/Ardalis.Specification/Builder/IOrderedSpecificationBuilder.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Builder/IOrderedSpecificationBuilder.cs
@@ -5,9 +5,7 @@ using System.Text;
 
 namespace Ardalis.Specification
 {
-    public interface IOrderedSpecificationBuilder<T>
+    public interface IOrderedSpecificationBuilder<T> : ISpecificationBuilder<T>
     {
-        IOrderedSpecificationBuilder<T> ThenBy(Expression<Func<T, object>> orderExpression);
-        IOrderedSpecificationBuilder<T> ThenByDescending(Expression<Func<T, object>> orderExpression);
     }
 }

--- a/ArdalisSpecification/src/Ardalis.Specification/Builder/ISpecificationBuilder.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Builder/ISpecificationBuilder.cs
@@ -7,21 +7,11 @@ namespace Ardalis.Specification
 {
     public interface ISpecificationBuilder<T, TResult> : ISpecificationBuilder<T>
     {
-        ISpecificationBuilder<T> Select(Expression<Func<T, TResult>> selector);
+        new Specification<T, TResult> Specification { get; }
     }
 
     public interface ISpecificationBuilder<T>
     {
-        ISpecificationBuilder<T> Where(Expression<Func<T, bool>> criteria);
-        IOrderedSpecificationBuilder<T> OrderBy(Expression<Func<T, object>> orderExpression);
-        IOrderedSpecificationBuilder<T> OrderByDescending(Expression<Func<T, object>> orderExpression);
-        ISpecificationBuilder<T> Include(string includeString);
-        IIncludableSpecificationBuilder<T, TProperty> Include<TProperty>(Expression<Func<T, TProperty>> includeExpression);
-        ISpecificationBuilder<T> EnableCache(string specificationName, params object[] args);
-        ISpecificationBuilder<T> Take(int take);
-        ISpecificationBuilder<T> Skip(int skip);
-        
-        [Obsolete]
-        ISpecificationBuilder<T> Paginate(int skip, int take);
+        Specification<T> Specification { get; }
     }
 }

--- a/ArdalisSpecification/src/Ardalis.Specification/Builder/IncludableBuilderExtensions.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Builder/IncludableBuilderExtensions.cs
@@ -8,25 +8,25 @@ namespace Ardalis.Specification
     public static class IncludableBuilderExtensions
     {
         public static IIncludableSpecificationBuilder<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
-            this IIncludableSpecificationBuilder<TEntity, TPreviousProperty> value,
+            this IIncludableSpecificationBuilder<TEntity, TPreviousProperty> previousBuilder,
             Expression<Func<TPreviousProperty, TProperty>> thenIncludeExpression)
             where TEntity : class
         {
             var propertyName = (thenIncludeExpression.Body as MemberExpression)?.Member?.Name;
-            value.Aggregator.AddNavigationPropertyName(propertyName);
+            previousBuilder.Aggregator.AddNavigationPropertyName(propertyName);
 
-            return new IncludableSpecificationBuilder<TEntity, TProperty>(value.Aggregator);
+            return new IncludableSpecificationBuilder<TEntity, TProperty>(previousBuilder.Specification, previousBuilder.Aggregator);
         }
 
         public static IIncludableSpecificationBuilder<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
-            this IIncludableSpecificationBuilder<TEntity, IEnumerable<TPreviousProperty>> value,
+            this IIncludableSpecificationBuilder<TEntity, IEnumerable<TPreviousProperty>> previousBuilder,
             Expression<Func<TPreviousProperty, TProperty>> thenIncludeExpression)
             where TEntity : class
         {
             var propertyName = (thenIncludeExpression.Body as MemberExpression)?.Member?.Name;
-            value.Aggregator.AddNavigationPropertyName(propertyName);
+            previousBuilder.Aggregator.AddNavigationPropertyName(propertyName);
 
-            return new IncludableSpecificationBuilder<TEntity, TProperty>(value.Aggregator);
+            return new IncludableSpecificationBuilder<TEntity, TProperty>(previousBuilder.Specification, previousBuilder.Aggregator);
         }
     }
 }

--- a/ArdalisSpecification/src/Ardalis.Specification/Builder/IncludableSpecificationBuilder.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Builder/IncludableSpecificationBuilder.cs
@@ -6,10 +6,13 @@ namespace Ardalis.Specification
 {
     public class IncludableSpecificationBuilder<T, TProperty> : IIncludableSpecificationBuilder<T, TProperty>
     {
+        public Specification<T> Specification { get; }
+
         public IIncludeAggregator Aggregator { get; }
 
-        public IncludableSpecificationBuilder(IIncludeAggregator aggregator)
+        public IncludableSpecificationBuilder(Specification<T> specification, IIncludeAggregator aggregator)
         {
+            Specification = specification;
             Aggregator = aggregator;
         }
     }

--- a/ArdalisSpecification/src/Ardalis.Specification/Builder/OrderedBuilderExtensions.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Builder/OrderedBuilderExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace Ardalis.Specification
+{
+    public static class OrderedBuilderExtensions
+    {
+        public static IOrderedSpecificationBuilder<T> ThenBy<T>(
+            this IOrderedSpecificationBuilder<T> orderedBuilder,
+            Expression<Func<T, object?>> orderExpression)
+        {
+            ((List<(Expression<Func<T, object?>> OrderExpression, OrderTypeEnum OrderType)>)orderedBuilder.Specification.OrderExpressions)
+                .Add((orderExpression, OrderTypeEnum.ThenBy));
+
+            return orderedBuilder;
+        }
+
+        public static IOrderedSpecificationBuilder<T> ThenByDescending<T>(
+            this IOrderedSpecificationBuilder<T> orderedBuilder,
+            Expression<Func<T, object?>> orderExpression)
+        {
+            ((List<(Expression<Func<T, object?>> OrderExpression, OrderTypeEnum OrderType)>)orderedBuilder.Specification.OrderExpressions)
+                .Add((orderExpression, OrderTypeEnum.ThenByDescending));
+
+            return orderedBuilder;
+        }
+    }
+}

--- a/ArdalisSpecification/src/Ardalis.Specification/Builder/OrderedSpecificationBuilder.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Builder/OrderedSpecificationBuilder.cs
@@ -7,23 +7,13 @@ namespace Ardalis.Specification
 {
     public class OrderedSpecificationBuilder<T> : IOrderedSpecificationBuilder<T>
     {
-        private readonly Specification<T> specification;
+        public Specification<T> Specification { get; }
 
         public OrderedSpecificationBuilder(Specification<T> specification)
         {
-            this.specification = specification;
+            this.Specification = specification;
         }
 
-        public IOrderedSpecificationBuilder<T> ThenBy(Expression<Func<T, object>> orderExpression)
-        {
-            ((List<(Expression<Func<T, object>> OrderExpression, OrderTypeEnum OrderType)>)specification.OrderExpressions).Add((orderExpression, OrderTypeEnum.ThenBy));
-            return this;
-        }
 
-        public IOrderedSpecificationBuilder<T> ThenByDescending(Expression<Func<T, object>> orderExpression)
-        {
-            ((List<(Expression<Func<T, object>> OrderExpression, OrderTypeEnum OrderType)>)specification.OrderExpressions).Add((orderExpression, OrderTypeEnum.ThenByDescending));
-            return this;
-        }
     }
 }

--- a/ArdalisSpecification/src/Ardalis.Specification/Builder/SpecificationBuilder.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Builder/SpecificationBuilder.cs
@@ -8,104 +8,22 @@ namespace Ardalis.Specification
 {
     public class SpecificationBuilder<T, TResult> : SpecificationBuilder<T>, ISpecificationBuilder<T, TResult>
     {
-        private readonly Specification<T, TResult> specification;
+        public new Specification<T, TResult> Specification { get; }
 
-        public SpecificationBuilder(Specification<T, TResult> specification) : base(specification)
+        public SpecificationBuilder(Specification<T, TResult> specification) 
+            : base(specification)
         {
-            this.specification = specification;
-        }
-
-        public ISpecificationBuilder<T> Select(Expression<Func<T, TResult>> selector)
-        {
-            specification.Selector = selector;
-            return this;
+            this.Specification = specification;
         }
     }
 
     public class SpecificationBuilder<T> : ISpecificationBuilder<T>
     {
-        private readonly Specification<T> specification;
-        private readonly IOrderedSpecificationBuilder<T> orderedSpecificationBuilder;
+        public Specification<T> Specification { get; }
 
         public SpecificationBuilder(Specification<T> specification)
         {
-            this.specification = specification;
-            this.orderedSpecificationBuilder = new OrderedSpecificationBuilder<T>(specification);
-        }
-
-        public ISpecificationBuilder<T> Where(Expression<Func<T, bool>> criteria)
-        {
-            ((List<Expression<Func<T, bool>>>)specification.WhereExpressions).Add(criteria);
-            return this;
-        }
-
-        public IIncludableSpecificationBuilder<T, TProperty> Include<TProperty>(Expression<Func<T, TProperty>> includeExpression)
-        {
-            var aggregator = new IncludeAggregator((includeExpression.Body as MemberExpression)?.Member?.Name);
-            var includeBuilder = new IncludableSpecificationBuilder<T, TProperty>(aggregator);
-
-            ((List<IIncludeAggregator>)specification.IncludeAggregators).Add(aggregator);
-            return includeBuilder;
-        }
-
-        public ISpecificationBuilder<T> Include(string includeString)
-        {
-            ((List<string>)specification.IncludeStrings).Add(includeString);
-            return this;
-        }
-
-        public IOrderedSpecificationBuilder<T> OrderBy(Expression<Func<T, object>> orderExpression)
-        {
-            ((List<(Expression<Func<T, object>> OrderExpression, OrderTypeEnum OrderType)>)specification.OrderExpressions).Add((orderExpression, OrderTypeEnum.OrderBy));
-            return orderedSpecificationBuilder;
-        }
-
-        public IOrderedSpecificationBuilder<T> OrderByDescending(Expression<Func<T, object>> orderExpression)
-        {
-            ((List<(Expression<Func<T, object>> OrderExpression, OrderTypeEnum OrderType)>)specification.OrderExpressions).Add((orderExpression, OrderTypeEnum.OrderByDescending));
-            return orderedSpecificationBuilder;
-        }
-
-        public ISpecificationBuilder<T> Take(int take)
-        {
-            if (specification.Take != null) throw new DuplicateTakeException();
-
-            specification.Take = take;
-            specification.IsPagingEnabled = true;
-            return this;
-        }
-
-        public ISpecificationBuilder<T> Skip(int skip)
-        {
-            if (specification.Skip != null) throw new DuplicateSkipException();
-
-            specification.Skip = skip;
-            specification.IsPagingEnabled = true;
-            return this;
-        }
-
-        [Obsolete]
-        public ISpecificationBuilder<T> Paginate(int skip, int take)
-        {
-            Skip(skip);
-            Take(take);
-            return this;
-        }
-
-        /// <summary>
-        /// Must be called after specifying criteria
-        /// </summary>
-        /// <param name="specificationName"></param>
-        /// <param name="args">Any arguments used in defining the specification</param>
-        public ISpecificationBuilder<T> EnableCache(string specificationName, params object[] args)
-        {
-            Guard.Against.NullOrEmpty(specificationName, nameof(specificationName));
-            Guard.Against.NullOrEmpty(specification.WhereExpressions, nameof(specification.WhereExpressions));
-
-            specification.CacheKey = $"{specificationName}-{string.Join("-", args)}";
-
-            specification.CacheEnabled = true;
-            return this;
+            this.Specification = specification;
         }
     }
 }

--- a/ArdalisSpecification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
@@ -1,0 +1,125 @@
+﻿using Ardalis.GuardClauses;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace Ardalis.Specification
+{
+    public static class SpecificationBuilderExtensions
+    {
+        public static ISpecificationBuilder<T> Where<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            Expression<Func<T, bool>> criteria)
+        {
+            ((List<Expression<Func<T, bool>>>)specificationBuilder.Specification.WhereExpressions).Add(criteria);
+
+            return specificationBuilder;
+        }
+
+        public static IOrderedSpecificationBuilder<T> OrderBy<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            Expression<Func<T, object>> orderExpression)
+        {
+            ((List<(Expression<Func<T, object>> OrderExpression, OrderTypeEnum OrderType)>)specificationBuilder.Specification.OrderExpressions)
+                .Add((orderExpression, OrderTypeEnum.OrderBy));
+
+            var orderedSpecificationBuilder = new OrderedSpecificationBuilder<T>(specificationBuilder.Specification);
+
+            return orderedSpecificationBuilder;
+        }
+
+        public static IOrderedSpecificationBuilder<T> OrderByDescending<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            Expression<Func<T, object>> orderExpression)
+        {
+            ((List<(Expression<Func<T, object>> OrderExpression, OrderTypeEnum OrderType)>)specificationBuilder.Specification.OrderExpressions)
+                .Add((orderExpression, OrderTypeEnum.OrderByDescending));
+
+            var orderedSpecificationBuilder = new OrderedSpecificationBuilder<T>(specificationBuilder.Specification);
+
+            return orderedSpecificationBuilder;
+        }
+
+        public static IIncludableSpecificationBuilder<T, TProperty> Include<T, TProperty>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            Expression<Func<T, TProperty>> includeExpression)
+        {
+            var aggregator = new IncludeAggregator((includeExpression.Body as MemberExpression)?.Member?.Name);
+            var includeBuilder = new IncludableSpecificationBuilder<T, TProperty>(specificationBuilder.Specification, aggregator);
+
+            ((List<IIncludeAggregator>)specificationBuilder.Specification.IncludeAggregators).Add(aggregator);
+            return includeBuilder;
+        }
+
+        public static ISpecificationBuilder<T> Include<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            string includeString)
+        {
+            ((List<string>)specificationBuilder.Specification.IncludeStrings).Add(includeString);
+            return specificationBuilder;
+        }
+
+        public static ISpecificationBuilder<T> Take<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            int take)
+        {
+            if (specificationBuilder.Specification.Take != null) throw new DuplicateTakeException();
+
+            specificationBuilder.Specification.Take = take;
+            specificationBuilder.Specification.IsPagingEnabled = true;
+            return specificationBuilder;
+        }
+
+        public static ISpecificationBuilder<T> Skip<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            int skip)
+        {
+            if (specificationBuilder.Specification.Skip != null) throw new DuplicateSkipException();
+
+            specificationBuilder.Specification.Skip = skip;
+            specificationBuilder.Specification.IsPagingEnabled = true;
+            return specificationBuilder;
+        }
+
+        [Obsolete]
+        public static ISpecificationBuilder<T> Paginate<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            int skip,
+            int take)
+        {
+            specificationBuilder.Skip(skip);
+            specificationBuilder.Take(take);
+
+            return specificationBuilder;
+        }
+
+        /// <summary>
+        /// Must be called after specifying criteria
+        /// </summary>
+        /// <param name="specificationName"></param>
+        /// <param name="args">Any arguments used in defining the specification</param>
+        public static ISpecificationBuilder<T> EnableCache<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            string specificationName, params object[] args)
+        {
+            Guard.Against.NullOrEmpty(specificationName, nameof(specificationName));
+            Guard.Against.NullOrEmpty(specificationBuilder.Specification.WhereExpressions, nameof(specificationBuilder.Specification.WhereExpressions));
+
+            specificationBuilder.Specification.CacheKey = $"{specificationName}-{string.Join("-", args)}";
+
+            specificationBuilder.Specification.CacheEnabled = true;
+
+            return specificationBuilder;
+        }
+
+        public static ISpecificationBuilder<T, TResult> Select<T, TResult>(
+            this ISpecificationBuilder<T, TResult> specificationBuilder,
+            Expression<Func<T, TResult>> selector)
+        {
+            specificationBuilder.Specification.Selector = selector;
+
+            return specificationBuilder;
+        }
+    }
+}

--- a/ArdalisSpecification/src/Ardalis.Specification/IRepositoryBase.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/IRepositoryBase.cs
@@ -15,9 +15,11 @@ namespace Ardalis.Specification
         Task<T?> GetByIdAsync<TId>(TId id);
         Task<T?> GetBySpecAsync(ISpecification<T> specification);
         Task<TResult> GetBySpecAsync<TResult>(ISpecification<T, TResult> specification);
+
         Task<List<T>> ListAsync();
         Task<List<T>> ListAsync(ISpecification<T> specification);
         Task<List<TResult>> ListAsync<TResult>(ISpecification<T, TResult> specification);
+
         Task<int> CountAsync(ISpecification<T> specification);
     }
 }

--- a/ArdalisSpecification/src/Ardalis.Specification/ISpecification.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/ISpecification.cs
@@ -12,13 +12,12 @@ namespace Ardalis.Specification
     public interface ISpecification<T>
     {
         IEnumerable<Expression<Func<T, bool>>> WhereExpressions { get; }
-        IEnumerable<string> IncludeStrings { get; }
-        IEnumerable<IIncludeAggregator> IncludeAggregators { get; }
         IEnumerable<(Expression<Func<T, object>> KeySelector, OrderTypeEnum OrderType)> OrderExpressions { get; }
+        IEnumerable<IIncludeAggregator> IncludeAggregators { get; }
+        IEnumerable<string> IncludeStrings { get; }
 
         int? Take { get; }
         int? Skip { get; }
-
         [Obsolete]
         bool IsPagingEnabled { get; }
 

--- a/ArdalisSpecification/src/Ardalis.Specification/Specification.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Specification.cs
@@ -40,7 +40,6 @@ namespace Ardalis.Specification
 
         public int? Skip { get; internal set; } = null;
 
-        [Obsolete]
         public bool IsPagingEnabled { get; internal set; } = false;
 
         public string? CacheKey { get; internal set; }

--- a/ArdalisSpecification/src/Ardalis.Specification/SpecificationEvaluatorBase.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/SpecificationEvaluatorBase.cs
@@ -21,10 +21,9 @@ namespace Ardalis.Specification
         {
             var query = inputQuery;
 
-            if (specification.WhereExpressions.Count() > 0)
+            foreach (var criteria in specification.WhereExpressions)
             {
-                query = specification.WhereExpressions.Aggregate(query,
-                                    (current, criteria) => current.Where(criteria));
+                query = query.Where(criteria);
             }
 
             // Need to check for null if <Nullable> is enabled.

--- a/ArdalisSpecificationEF/src/Ardalis.Specification.EF/Ardalis.Specification.EntityFrameworkCore.csproj
+++ b/ArdalisSpecificationEF/src/Ardalis.Specification.EF/Ardalis.Specification.EntityFrameworkCore.csproj
@@ -12,8 +12,8 @@
     <Summary>EF Core plugin package to Ardalis.Specification containing EF Core evaluator and abstract repository.</Summary>
     <RepositoryUrl>https://github.com/ardalis/specification</RepositoryUrl>
     <PackageTags>spec;specification;repository;ddd;ef;ef core;entity framework;entity framework core</PackageTags>
-    <Version>4.0.0</Version>
-    <PackageReleaseNotes>New API for building the specifications.</PackageReleaseNotes>
+    <Version>4.1.0</Version>
+    <PackageReleaseNotes>The dependency updated to project reference.</PackageReleaseNotes>
     <AssemblyName>Ardalis.Specification.EntityFrameworkCore</AssemblyName>
     <PackageIcon>icon.png</PackageIcon>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
The internal builder infrastructure is refactored. No breaking API changes for end users.
Now, everything can be written in one large chain. You can go back after Then definitions, and continue building the specification.

This is first from a series of PRs. But we need this restructuring, in order to PR the new features.

```
public class StoresOrderedSpecByName : Specification<Store>
{
    public StoresOrderedSpecByName()
    {
        Query.Where(x => x.Name == "something")
            .Include(x => x.Company)
                .ThenInclude(x => x.Stores)
            .Include(x => x.Address)
            .OrderBy(x => x.Name)
                .ThenBy(x => x.Id)
            .Skip(2)
            .Take(10);
    }
}
```