### PR TITLE
Allow users to define their own wildcards for Search feature.

### DIFF
--- a/ArdalisSpecificationEF/src/Ardalis.Specification.EF/SearchExtension.cs
+++ b/ArdalisSpecificationEF/src/Ardalis.Specification.EF/SearchExtension.cs
@@ -29,7 +29,7 @@ namespace Ardalis.Specification.EntityFrameworkCore
                                         like,
                                         functions,
                                         (propertySelector as LambdaExpression)?.Body,
-                                        Expression.Constant("%" + criteria.searchTerm + "%"));
+                                        Expression.Constant(criteria.searchTerm));
 
                 expr = expr == null ? (Expression)likeExpression : Expression.OrElse(expr, likeExpression);
             }


### PR DESCRIPTION
The automatic addition of "%" wildcards is removed from the search evaluator. The users can add their own wildcards while defining the specification. This way, the `Search` functionality can be used for queries where you need some complex wildcard usage.

As for querying substrings, using a LINQ `Contains()` method is good enough. I might have been in delusion all this time. I remember clearly that in certain scenarios Contains() couldn't be translated, but can't remember the cases now :). 

Anyhow, now users have an alternative way of doing things.