### PR TITLE
 Add "AsNoTracking" feature. (#71)

### DIFF
--- a/ArdalisSpecification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
@@ -134,5 +134,12 @@ namespace Ardalis.Specification
 
             return specificationBuilder;
         }
+
+        public static ISpecificationBuilder<T> AsNoTracking<T>(
+            this ISpecificationBuilder<T> specificationBuilder)
+        {
+            specificationBuilder.Specification.AsNoTracking = true;
+            return specificationBuilder;
+        }
     }
 }

--- a/ArdalisSpecification/src/Ardalis.Specification/ISpecification.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/ISpecification.cs
@@ -24,5 +24,7 @@ namespace Ardalis.Specification
 
         bool CacheEnabled { get; }
         string? CacheKey { get; }
+
+        bool AsNoTracking { get; }
     }
 }

--- a/ArdalisSpecification/src/Ardalis.Specification/Specification.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Specification.cs
@@ -49,5 +49,7 @@ namespace Ardalis.Specification
         public string? CacheKey { get; internal set; }
 
         public bool CacheEnabled { get; internal set; }
+
+        public bool AsNoTracking { get; internal set; } = false;
     }
 }

--- a/ArdalisSpecificationEF/src/Ardalis.Specification.EF/SpecificationEvaluator.cs
+++ b/ArdalisSpecificationEF/src/Ardalis.Specification.EF/SpecificationEvaluator.cs
@@ -85,6 +85,11 @@ namespace Ardalis.Specification.EntityFrameworkCore
                 query = query.Take(specification.Take.Value);
             }
 
+            if (specification.AsNoTracking)
+            {
+                query = query.AsNoTracking();
+            }
+
             return query;
         }
     }

--- a/ArdalisSpecificationEF/tests/Ardalis.Specification.EF.IntegrationTests/SpecificationTests.cs
+++ b/ArdalisSpecificationEF/tests/Ardalis.Specification.EF.IntegrationTests/SpecificationTests.cs
@@ -72,5 +72,21 @@ namespace Ardalis.Specification.EntityFrameworkCore.IntegrationTests
             result.Stores.Count.Should().BeGreaterThan(49);
             result.Stores.Select(x => x.Products).Count().Should().BeGreaterThan(1);
         }
+
+        [Fact]
+        public async Task GetCompanyUsingRepositoryAnd_CompanyAsUntrackedSpec_ShouldNotBeTracked()
+        {
+            var result = (await companyRepository.ListAsync(new CompanySpec(CompanySeed.VALID_COMPANY_ID))).SingleOrDefault();
+            dbContext.Entry(result).State = Microsoft.EntityFrameworkCore.EntityState.Detached;
+            
+            result.Should().NotBeNull();
+            result.Name.Should().Be(CompanySeed.VALID_COMPANY_NAME);
+
+            result = (await companyRepository.ListAsync(new CompanyAsUntrackedSpec(CompanySeed.VALID_COMPANY_ID))).SingleOrDefault();
+
+            result.Should().NotBeNull();
+            result.Name.Should().Be(CompanySeed.VALID_COMPANY_NAME);
+            dbContext.Entry(result).State.Should().Be(Microsoft.EntityFrameworkCore.EntityState.Detached);
+        }
     }
 }

--- a/ArdalisSpecificationEF/tests/Ardalis.Specification.EF.IntegrationTests/Specs/CompanyAsUntrackedSpec.cs
+++ b/ArdalisSpecificationEF/tests/Ardalis.Specification.EF.IntegrationTests/Specs/CompanyAsUntrackedSpec.cs
@@ -1,0 +1,15 @@
+﻿using Ardalis.Specification.EntityFrameworkCore.IntegrationTests.Data;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ardalis.Specification.EntityFrameworkCore.IntegrationTests.Specs
+{
+    public class CompanyAsUntrackedSpec : Specification<Company>
+    {
+        public CompanyAsUntrackedSpec(int id)
+        {
+            Query.Where(company => company.Id == id).AsNoTracking();
+        }
+    }
+}

--- a/ArdalisSpecificationEF/tests/Ardalis.Specification.EF.IntegrationTests/Specs/CompanySpec.cs
+++ b/ArdalisSpecificationEF/tests/Ardalis.Specification.EF.IntegrationTests/Specs/CompanySpec.cs
@@ -1,0 +1,15 @@
+﻿using Ardalis.Specification.EntityFrameworkCore.IntegrationTests.Data;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ardalis.Specification.EntityFrameworkCore.IntegrationTests.Specs
+{
+    public class CompanySpec : Specification<Company>
+    {
+        public CompanySpec(int id)
+        {
+            Query.Where(company => company.Id == id);
+        }
+    }
+}


### PR DESCRIPTION
This PR provides `AsNoTracking()` as an extension for `Query` in a `Specification`.

The test itself is a bit tricky. Initially dbcontext tracks all entities as they are seeded. This requires me to fetch the record and detach it from the context first.

On EFCore5 this would be more easily done with `dbcontext.ChangeTracker.Clear();`