### PR TITLE
Updated expression paremeter for OrderBy extension.

### DIFF
--- a/ArdalisSpecification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
@@ -19,9 +19,9 @@ namespace Ardalis.Specification
 
         public static IOrderedSpecificationBuilder<T> OrderBy<T>(
             this ISpecificationBuilder<T> specificationBuilder,
-            Expression<Func<T, object>> orderExpression)
+            Expression<Func<T, object?>> orderExpression)
         {
-            ((List<(Expression<Func<T, object>> OrderExpression, OrderTypeEnum OrderType)>)specificationBuilder.Specification.OrderExpressions)
+            ((List<(Expression<Func<T, object?>> OrderExpression, OrderTypeEnum OrderType)>)specificationBuilder.Specification.OrderExpressions)
                 .Add((orderExpression, OrderTypeEnum.OrderBy));
 
             var orderedSpecificationBuilder = new OrderedSpecificationBuilder<T>(specificationBuilder.Specification);
@@ -31,9 +31,9 @@ namespace Ardalis.Specification
 
         public static IOrderedSpecificationBuilder<T> OrderByDescending<T>(
             this ISpecificationBuilder<T> specificationBuilder,
-            Expression<Func<T, object>> orderExpression)
+            Expression<Func<T, object?>> orderExpression)
         {
-            ((List<(Expression<Func<T, object>> OrderExpression, OrderTypeEnum OrderType)>)specificationBuilder.Specification.OrderExpressions)
+            ((List<(Expression<Func<T, object?>> OrderExpression, OrderTypeEnum OrderType)>)specificationBuilder.Specification.OrderExpressions)
                 .Add((orderExpression, OrderTypeEnum.OrderByDescending));
 
             var orderedSpecificationBuilder = new OrderedSpecificationBuilder<T>(specificationBuilder.Specification);


### PR DESCRIPTION
This is a small change, it fixes the nullability warnings. The expression parameter of the OrderBy extension should be defined as `Expression<Func<T, object?>> orderExpression`. So, in the specification, we can use `Query.OrderBy(x => x.Name)` and we don't have to use ! to avoid the warnings.

During the evaluation, the name of the property is retrieved from the given expression, the value is not of any importance. Accepting nullable object does not impact anything.
