### PR TITLE
Create specification advanced

### DIFF
--- a/docs/usage/create-specifications.md
+++ b/docs/usage/create-specifications.md
@@ -48,3 +48,7 @@ public class ItemByIdSpec : Specification<Item>, ISingleResultSpecification
     }
 }
 ```
+
+## Advanced Specification
+
+From here, additional operators can be used to further refine the Specification. These operators follow LINQ syntax and are described in more detail in the [Features](../features/index.md) section.

--- a/docs/usage/create-specifications.md
+++ b/docs/usage/create-specifications.md
@@ -5,6 +5,8 @@ parent: Usage
 nav_order: 1
 ---
 
+# How to Create Specifications
+
 ## Basic Specification
 
 A Specification class should inherit from `Specification<T>`, where `T` is the type being retrieved in the query:


### PR DESCRIPTION
note added about additional operators, so people aren't confused into thinking where is the only operator that can be used. 

Also fixed top level heading.