### PR TITLE
Added Evaluate function to check if an entity fulfills to the specifi…

### DIFF
--- a/ArdalisSpecification/src/Ardalis.Specification/Evaluators/IInMemorySpecificationEvaluator.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Evaluators/IInMemorySpecificationEvaluator.cs
@@ -9,5 +9,6 @@ namespace Ardalis.Specification
     {
         IEnumerable<TResult> Evaluate<T, TResult>(IEnumerable<T> source, ISpecification<T, TResult> specification);
         IEnumerable<T> Evaluate<T>(IEnumerable<T> source, ISpecification<T> specification);
+        bool Evaluate<T>(T source, ISpecification<T> specification);
     }
 }

--- a/ArdalisSpecification/src/Ardalis.Specification/Evaluators/InMemorySpecificationEvaluator.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Evaluators/InMemorySpecificationEvaluator.cs
@@ -56,5 +56,10 @@ namespace Ardalis.Specification
                 ? source
                 : specification.PostProcessingAction(source);
         }
+
+        public bool Evaluate<T>(T source, ISpecification<T> specification)
+        {
+            return Evaluate(new[] { source }, specification).Any();
+        }
     }
 }

--- a/ArdalisSpecification/src/Ardalis.Specification/ISpecification.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/ISpecification.cs
@@ -20,7 +20,10 @@ namespace Ardalis.Specification
         /// The transform function to apply to the result of the query encapsulated by the <see cref="ISpecification{T, TResult}"/>.
         /// </summary>
         new Func<IEnumerable<TResult>, IEnumerable<TResult>>? PostProcessingAction { get; }
-
+        /// <summary>
+        /// Returns a IEnumerable of entities that fulfilled to the specification
+        /// </summary>
+        /// <param name="entities"></param>
         new IEnumerable<TResult> Evaluate(IEnumerable<T> entities);
     }
 
@@ -94,6 +97,18 @@ namespace Ardalis.Specification
         bool AsSplitQuery { get; }
         bool AsNoTrackingWithIdentityResolution { get; }
 
+        /// <summary>
+        /// Returns a IEnumerable of entities that fulfilled to the specification
+        /// </summary>
+        /// <param name="entities"></param>
+        /// <returns></returns>
         IEnumerable<T> Evaluate(IEnumerable<T> entities);
+
+        /// <summary>
+        /// Returns whether or not the entity fulfills to the specification 
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        bool Evaluate(T entity);
     }
 }

--- a/ArdalisSpecification/src/Ardalis.Specification/Specification.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/Specification.cs
@@ -1,5 +1,4 @@
-﻿using Ardalis.GuardClauses;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Text;
@@ -50,15 +49,22 @@ namespace Ardalis.Specification
             this.Query = new SpecificationBuilder<T>(this);
         }
 
+        /// <inheritdoc/>
         public virtual IEnumerable<T> Evaluate(IEnumerable<T> entities)
         {
             return Evaluator.Evaluate(entities, this);
         }
 
         /// <inheritdoc/>
+        public virtual bool Evaluate(T entity)
+        {
+            return Evaluator.Evaluate(entity, this);
+        }
+
+        /// <inheritdoc/>
         public IEnumerable<Expression<Func<T, bool>>> WhereExpressions { get; } = new List<Expression<Func<T, bool>>>();
 
-        public IEnumerable<(Expression<Func<T, object>> KeySelector, OrderTypeEnum OrderType)> OrderExpressions { get; } = 
+        public IEnumerable<(Expression<Func<T, object>> KeySelector, OrderTypeEnum OrderType)> OrderExpressions { get; } =
             new List<(Expression<Func<T, object>> KeySelector, OrderTypeEnum OrderType)>();
 
         /// <inheritdoc/>

--- a/ArdalisSpecification/tests/Ardalis.Specification.UnitTests/SpecificationEntityEvaluatorTests.cs
+++ b/ArdalisSpecification/tests/Ardalis.Specification.UnitTests/SpecificationEntityEvaluatorTests.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using FluentAssertions;
+using Ardalis.Specification.UnitTests.Fixture.Entities;
+using Ardalis.Specification.UnitTests.Fixture.Specs;
+using Xunit;
+
+namespace Ardalis.Specification.UnitTests
+{
+    public class SpecificationEntityEvaluatorTests
+    {
+        [Fact]
+        public void ReturnsTrueForEmptySpec_StoreEmptySpec()
+        {
+            var store = new Store
+            {
+                Id = 1
+            };
+            var evaluation = new StoreEmptySpec().Evaluate(store);
+
+            evaluation.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ReturnsTrueForSameId_StoreByIdSpec()
+        {
+            var store = new Store
+            {
+                Id = 1
+            };
+            var evaluation = new StoreByIdSpec(1).Evaluate(store);
+
+            evaluation.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ReturnsFalseForDiffrentId_StoreByIdSpec()
+        {
+            var store = new Store
+            {
+                Id = 2
+            };
+            var evaluation = new StoreByIdSpec(1).Evaluate(store);
+
+            evaluation.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ReturnsTrueForIdAndName_StoreByIdAndNameSpec()
+        {
+            var store = new Store
+            {
+                Id = 1, Name = "name"
+            };
+            var evaluation = new StoreByIdAndNameSpec(1, "name").Evaluate(store);
+
+            evaluation.Should().BeTrue();
+        } 
+        
+        [Fact]
+        public void ReturnsFalseForIdAndDifferentName_StoreByIdAndNameSpec()
+        {
+            var store = new Store
+            {
+                Id = 1,
+                Name = "different"
+            };
+            var evaluation = new StoreByIdAndNameSpec(1, "name").Evaluate(store);
+
+            evaluation.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ReturnsTrueForIdAndIncludeStatements_StoreByIdIncludeAddressAndProductsSpec()
+        {
+            var store = new Store
+            {
+                Id = 1
+            };
+            var evaluation = new StoreByIdIncludeAddressAndProductsSpec(1).Evaluate(store);
+
+            evaluation.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ReturnsFalseForDifferentIdAndIncludeStatements_StoreByIdIncludeAddressAndProductsSpec()
+        {
+            var store = new Store
+            {
+                Id = 2
+            };
+            var evaluation = new StoreByIdIncludeAddressAndProductsSpec(1).Evaluate(store);
+
+            evaluation.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ReturnsTrueForCompanyIdAndOrderedStatements_StoresByCompanyOrderedDescByNameThenByDescIdSpec()
+        {
+            var store = new Store
+            {
+                CompanyId = 1
+            };
+            var evaluation = new StoresByCompanyOrderedDescByNameThenByDescIdSpec(1).Evaluate(store);
+
+            evaluation.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ReturnsFalseForDifferentIdAndIncludeStatements_StoresByCompanyOrderedDescByNameThenByDescIdSpec()
+        {
+            var store = new Store
+            {
+                CompanyId = 2
+            };
+            var evaluation = new StoresByCompanyOrderedDescByNameThenByDescIdSpec(1).Evaluate(store);
+
+            evaluation.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ReturnsTrueForPaginatedSpec_StoreNamesPaginatedSpec()
+        {
+            var store = new Store
+            {
+                Id = 1
+            };
+            var evaluation = new StoreNamesPaginatedSpec(0, 5).Evaluate(store);
+            evaluation.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ReturnsTrueForCompanyIdAndPaginatedSpec_StoresByCompanyPaginatedSpec()
+        {
+            var store = new Store
+            {
+                Id = 1,
+                CompanyId = 2
+            };
+            var evaluation = new StoresByCompanyPaginatedSpec(2,0, 5).Evaluate(store);
+            evaluation.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ReturnsFalseForDifferentCompanyIdAndPaginatedSpec_StoresByCompanyPaginatedSpec()
+        {
+            var store = new Store
+            {
+                Id = 1,
+                CompanyId = 1
+            };
+            var evaluation = new StoresByCompanyPaginatedSpec(2, 0, 5).Evaluate(store);
+            evaluation.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ReturnsFalseForWhereAndPaginatedSpec_StoresByCompanyPaginatedSpec()
+        {
+            var store = new Store
+            {
+                Id = 1,
+                CompanyId = 2
+            };
+            var evaluation = new StoresByCompanyPaginatedSpec(2, 0, 5).Evaluate(store);
+            evaluation.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ThrowsNotSupportedExceptionForSearchSpec_StoreSearchByNameOrCitySpec()
+        {
+            var store = new Store
+            {
+                Name = "spec",
+                City = "speccity"
+            };
+            Assert.Throws<NotSupportedException>(() => new StoreSearchByNameOrCitySpec("speccity").Evaluate(store));
+        }
+    }
+}


### PR DESCRIPTION
I'll start with an example why you even want to Evaluate against one entity.

Let's say I have a VerificationCodeService with SomeMethod:

``` c#
public async Task SomeMethod()
{
    var codes = await _verificationCodeRepository.ListAsync(new ValidVerificationCodeSpec());

    foreach (var code in codes)
    {
        if (somethingWillDestroyTheCode)
        {
            code.Destroy();
        }
        if (!code.IsValid())
        {
            //Do stuff for invalid case
        }
    }
}
```

I get all the verificationcodes that are valid using the ValidVerificationCodeSpec:
``` c#
public class ValidVerificationCodeSpec: Specification<VerificationCode>
{
    public ValidVerificationCodeSpec()
    {
        Query
            .Where(vc => vc.DateUsed == null)
            .Where(vc => vc.DateCreated.AddMinutes(30) > DateTime.Now);
    }
}
```
The verification code object has a method IsValid(). This shares the same logic used in the ValidVerificationCodeSpec.
Right now I can reuse the code but it reads difficult.

``` c#
public bool IsValid()
{
    return new ValidVerificationCodeSpec().Evaluate(new[] { this }).Any();
}
```
It would read much easier if I just can say `.Evaluate(this)`.
``` c#
public bool IsValid()
{
    return new ValidVerificationCodeSpec().Evaluate(this);
}
```
If the business requirements ever change I don't have to worry about other places where I need to implement the change.

I'd love to get some feedback on this.

Some things still to consider.

- It only makes sense for where clauses to evaluate against one entity. The developer can still make a mistake by using the wrong specification.


