### PR TITLE
added interface ISingleResultSpecification<T>

### DIFF
--- a/ArdalisSpecification/src/Ardalis.Specification/ISingleResultSpecificationOfT.cs
+++ b/ArdalisSpecification/src/Ardalis.Specification/ISingleResultSpecificationOfT.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ardalis.Specification
+{
+    public interface ISingleResultSpecification<T> : ISpecification<T>, ISingleResultSpecification
+    {
+
+    }
+}


### PR DESCRIPTION
Added interface `ISingleResultSpecification<T>` to use `ISpecification<T>` + `ISingleResultSpecification` without generic constraints.

This fixes #126 
