### PR TITLE
Update packages to version 5.2.0

### DIFF
--- a/.github/workflows/build-test-ef6.yml
+++ b/.github/workflows/build-test-ef6.yml
@@ -11,10 +11,10 @@ jobs:
     
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET
+    - name: Setup dotnet
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.400
+        dotnet-version: 5.0.x
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
     - name: Build with dotnet

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v1
-    - name: Setup .NET Core
+    - uses: actions/checkout@v2
+    - name: Setup dotnet
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.103
+        dotnet-version: 5.0.x
     - name: Build with dotnet
       run: |
         dotnet build Specification/src/Ardalis.Specification/Ardalis.Specification.csproj --configuration Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.300
+          dotnet-version: 5.0.x
       
       # Publish
       - name: publish on version change

--- a/.github/workflows/publishef6.yml
+++ b/.github/workflows/publishef6.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main # Your default release branch
     paths:
-      - 'Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/**'
+      - 'Specification.EntityFramework6/src/**'
 jobs:
   publish:
     name: list on nuget
@@ -17,7 +17,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.300
+          dotnet-version: 5.0.x
       
       - name: Setup MSBuild.exe
         uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/publishefcore.yml
+++ b/.github/workflows/publishefcore.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main # Your default release branch
     paths:
-      - 'Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/**'
+      - 'Specification.EntityFrameworkCore/src/**'
 jobs:
   publish:
     name: list on nuget
@@ -17,7 +17,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.300
+          dotnet-version: 5.0.x
       
       # Publish
       - name: publish on version change

--- a/Ardalis.Specification.sln
+++ b/Ardalis.Specification.sln
@@ -26,12 +26,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docker", "Docker", "{A74A4C
 		RunTests.sh = RunTests.sh
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AzurePipeline", "AzurePipeline", "{900638AF-E2F6-4FC9-9A97-E305C23F74FB}"
-	ProjectSection(SolutionItems) = preProject
-		azure-pipelines.yml.obsolete = azure-pipelines.yml.obsolete
-		GetCoverage.sh = GetCoverage.sh
-	EndProjectSection
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Items", "_Solution Items", "{C443291A-7311-455F-9AC6-995EB29DD6D2}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md

--- a/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Ardalis.Specification.EntityFramework6.csproj
+++ b/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Ardalis.Specification.EntityFramework6.csproj
@@ -14,7 +14,7 @@
     <Summary>EF6 plugin package to Ardalis.Specification containing EF6 evaluator and abstract repository.</Summary>
     <RepositoryUrl>https://github.com/ardalis/specification</RepositoryUrl>
     <PackageTags>spec;specification;repository;ddd;ef;ef6;entity framework</PackageTags>
-    <Version>5.1.0</Version>
+    <Version>5.2.0</Version>
     <PackageReleaseNotes>
       Initial release.
     </PackageReleaseNotes>

--- a/Specification.EntityFramework6/tests/Ardalis.Specification.EntityFramework6.IntegrationTests/Ardalis.Specification.EntityFramework6.IntegrationTests.csproj
+++ b/Specification.EntityFramework6/tests/Ardalis.Specification.EntityFramework6.IntegrationTests/Ardalis.Specification.EntityFramework6.IntegrationTests.csproj
@@ -15,17 +15,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="altcover" Version="8.1.817" />
-    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+    <PackageReference Include="altcover" Version="8.2.821" />
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MartinCostello.SqlLocalDb" Version="3.0.0" />
-    <PackageReference Include="ReportGenerator" Version="4.8.7" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="MartinCostello.SqlLocalDb" Version="3.0.1" />
+    <PackageReference Include="ReportGenerator" Version="4.8.12" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
@@ -30,13 +30,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.9" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
@@ -12,9 +12,9 @@
     <Summary>EF Core plugin package to Ardalis.Specification containing EF Core evaluator and abstract repository.</Summary>
     <RepositoryUrl>https://github.com/ardalis/specification</RepositoryUrl>
     <PackageTags>spec;specification;repository;ddd;ef;ef core;entity framework;entity framework core</PackageTags>
-    <Version>5.1.0</Version>
+    <Version>5.2.0</Version>
     <PackageReleaseNotes>
-      Added cancellation token support to repository types.
+      Added CountAsync without specification in the base repository. Added support for EF Core 3 for .NET Standard 2.0 TFM.
     </PackageReleaseNotes>
     <AssemblyName>Ardalis.Specification.EntityFrameworkCore</AssemblyName>
     <PackageIcon>icon.png</PackageIcon>

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests.csproj
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests.csproj
@@ -7,18 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="altcover" Version="8.1.817" />
-    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+    <PackageReference Include="altcover" Version="8.2.821" />
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MartinCostello.SqlLocalDb" Version="3.0.0" />
-    <PackageReference Include="ReportGenerator" Version="4.8.7" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.4" />
+    <PackageReference Include="MartinCostello.SqlLocalDb" Version="3.0.1" />
+    <PackageReference Include="ReportGenerator" Version="4.8.12" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Specification/src/Ardalis.Specification/Ardalis.Specification.csproj
+++ b/Specification/src/Ardalis.Specification/Ardalis.Specification.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="3.1.0" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="3.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   

--- a/Specification/src/Ardalis.Specification/Ardalis.Specification.csproj
+++ b/Specification/src/Ardalis.Specification/Ardalis.Specification.csproj
@@ -12,9 +12,9 @@
     <Summary>A simple package with a base Specification class, for use in creating queries that work with Repository types.</Summary>
     <RepositoryUrl>https://github.com/ardalis/specification</RepositoryUrl>
     <PackageTags>spec;specification;repository;ddd</PackageTags>
-    <Version>5.1.0</Version>
+    <Version>5.2.0</Version>
     <PackageReleaseNotes>
-    Added cancellation token support to repository types.
+      Added ISingleResultSpecification generic interface.
     </PackageReleaseNotes>
     <AssemblyName>Ardalis.Specification</AssemblyName>
     <PackageIcon>icon.png</PackageIcon>

--- a/Specification/src/Ardalis.Specification/Ardalis.Specification.csproj
+++ b/Specification/src/Ardalis.Specification/Ardalis.Specification.csproj
@@ -26,7 +26,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="3.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   

--- a/Specification/src/Ardalis.Specification/Builder/SpecificationBuilder.cs
+++ b/Specification/src/Ardalis.Specification/Builder/SpecificationBuilder.cs
@@ -1,5 +1,4 @@
-﻿using Ardalis.GuardClauses;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Text;

--- a/Specification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
+++ b/Specification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Ardalis.GuardClauses;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Text;
@@ -145,7 +144,10 @@ namespace Ardalis.Specification
             this ISpecificationBuilder<T> specificationBuilder,
             string specificationName, params object[] args) where T : class
         {
-            Guard.Against.NullOrEmpty(specificationName, nameof(specificationName));
+            if (string.IsNullOrEmpty(specificationName))
+            {
+                throw new ArgumentException($"Required input {specificationName} was null or empty.", specificationName);
+            }
 
             specificationBuilder.Specification.CacheKey = $"{specificationName}-{string.Join("-", args)}";
 

--- a/Specification/src/Ardalis.Specification/Specification.cs
+++ b/Specification/src/Ardalis.Specification/Specification.cs
@@ -1,5 +1,4 @@
-﻿using Ardalis.GuardClauses;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Text;

--- a/Specification/tests/Ardalis.Specification.UnitTests/Ardalis.Specification.UnitTests.csproj
+++ b/Specification/tests/Ardalis.Specification.UnitTests/Ardalis.Specification.UnitTests.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="ReportGenerator" Version="4.8.7" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="ReportGenerator" Version="4.8.12" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/sample/Ardalis.SampleApp.Core/Ardalis.SampleApp.Core.csproj
+++ b/sample/Ardalis.SampleApp.Core/Ardalis.SampleApp.Core.csproj
@@ -5,16 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="3.1.0" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="3.2.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Specification\src\Ardalis.Specification\Ardalis.Specification.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="ValueObjects\" />
-    <Folder Include="Services\" />
   </ItemGroup>
 
 </Project>

--- a/sample/Ardalis.SampleApp.Infrastructure/Ardalis.SampleApp.Infrastructure.csproj
+++ b/sample/Ardalis.SampleApp.Infrastructure/Ardalis.SampleApp.Infrastructure.csproj
@@ -1,25 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.4">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.4" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.15">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/Ardalis.SampleApp.Web/Ardalis.SampleApp.Web.csproj
+++ b/sample/Ardalis.SampleApp.Web/Ardalis.SampleApp.Web.csproj
@@ -1,30 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.4" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.15">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Updated dotnet SDKs to 5.0.x in all GitHub workflows
- Updated Nuget package dependencies for all projects.

Once the PR is merged, the following packages will be updated to v5.2.0. Not sure if we can do it all at once like this. I don't know how Nuget behaves in case EF plugin packages are published before the base package. Hopefully we can :)
- Ardalis.Specification
- Ardalis.Specification.EntityFrameworkCore
- Ardalis.Specification.EntityFramework6

Fixes #147 