### PR TITLE
Implement specification validators.

### DIFF
--- a/Specification.EntityFramework6/tests/Ardalis.Specification.EntityFramework6.IntegrationTests/RepositoryOfT_ListAsync.cs
+++ b/Specification.EntityFramework6/tests/Ardalis.Specification.EntityFramework6.IntegrationTests/RepositoryOfT_ListAsync.cs
@@ -167,7 +167,7 @@ namespace Ardalis.Specification.EntityFramework6.IntegrationTests
 
             result.Should().NotBeNull();
             result.Should().ContainSingle();
-            result[0].Id.Should().Be(StoreSeed.VALID_Search_City_ID);
+            result[0].Id.Should().Be(StoreSeed.VALID_Search_ID);
             result[0].City.Should().Contain(StoreSeed.VALID_Search_City_Key);
         }
     }

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/IgnoreQueryFiltersEvaluator.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/IgnoreQueryFiltersEvaluator.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Ardalis.Specification.EntityFrameworkCore
+{
+    public class IgnoreQueryFiltersEvaluator : IEvaluator
+    {
+        private IgnoreQueryFiltersEvaluator() { }
+        public static IgnoreQueryFiltersEvaluator Instance { get; } = new IgnoreQueryFiltersEvaluator();
+
+        public bool IsCriteriaEvaluator { get; } = true;
+
+        public IQueryable<T> GetQuery<T>(IQueryable<T> query, ISpecification<T> specification) where T : class
+        {
+            if (specification.IgnoreQueryFilters)
+            {
+                query = query.IgnoreQueryFilters();
+            }
+
+            return query;
+        }
+    }
+}

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SpecificationEvaluator.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SpecificationEvaluator.cs
@@ -29,6 +29,7 @@ namespace Ardalis.Specification.EntityFrameworkCore
                 OrderEvaluator.Instance,
                 PaginationEvaluator.Instance,
                 AsNoTrackingEvaluator.Instance,
+                IgnoreQueryFiltersEvaluator.Instance,
 #if NETSTANDARD2_1
                 AsSplitQueryEvaluator.Instance,
                 AsNoTrackingWithIdentityResolutionEvaluator.Instance

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/RepositoryOfT_ListAsync.cs
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/RepositoryOfT_ListAsync.cs
@@ -193,7 +193,7 @@ namespace Ardalis.Specification.EntityFrameworkCore.IntegrationTests
 
             result.Should().NotBeNull();
             result.Should().ContainSingle();
-            result[0].Id.Should().Be(StoreSeed.VALID_Search_City_ID);
+            result[0].Id.Should().Be(StoreSeed.VALID_Search_ID);
             result[0].City.Should().Contain(StoreSeed.VALID_Search_City_Key);
         }
     }

--- a/Specification/src/Ardalis.Specification/Builder/CacheSpecificationBuilder.cs
+++ b/Specification/src/Ardalis.Specification/Builder/CacheSpecificationBuilder.cs
@@ -3,10 +3,17 @@
     public class CacheSpecificationBuilder<T> : ICacheSpecificationBuilder<T> where T : class
     {
         public Specification<T> Specification { get; }
+        public bool IsChainDiscarded { get; set; }
 
         public CacheSpecificationBuilder(Specification<T> specification)
+            :this(specification, false)
         {
-            Specification = specification;
+        }
+
+        public CacheSpecificationBuilder(Specification<T> specification, bool isChainDiscarded)
+        {
+            this.Specification = specification;
+            this.IsChainDiscarded = isChainDiscarded;
         }
     }
 }

--- a/Specification/src/Ardalis.Specification/Builder/ICacheSpecificationBuilder.cs
+++ b/Specification/src/Ardalis.Specification/Builder/ICacheSpecificationBuilder.cs
@@ -2,5 +2,6 @@
 {
     public interface ICacheSpecificationBuilder<T> : ISpecificationBuilder<T> where T : class
     {
+        bool IsChainDiscarded { get; set; }
     }
 }

--- a/Specification/src/Ardalis.Specification/Builder/IIncludableSpecificationBuilder.cs
+++ b/Specification/src/Ardalis.Specification/Builder/IIncludableSpecificationBuilder.cs
@@ -6,5 +6,6 @@ namespace Ardalis.Specification
 {
     public interface IIncludableSpecificationBuilder<T, out TProperty> : ISpecificationBuilder<T> where T : class
     {
+        bool IsChainDiscarded { get; set; }
     }
 }

--- a/Specification/src/Ardalis.Specification/Builder/IOrderedSpecificationBuilder.cs
+++ b/Specification/src/Ardalis.Specification/Builder/IOrderedSpecificationBuilder.cs
@@ -7,5 +7,6 @@ namespace Ardalis.Specification
 {
     public interface IOrderedSpecificationBuilder<T> : ISpecificationBuilder<T>
     {
+        bool IsChainDiscarded { get; set; }
     }
 }

--- a/Specification/src/Ardalis.Specification/Builder/IncludableBuilderExtensions.cs
+++ b/Specification/src/Ardalis.Specification/Builder/IncludableBuilderExtensions.cs
@@ -11,11 +11,32 @@ namespace Ardalis.Specification
             Expression<Func<TPreviousProperty, TProperty>> thenIncludeExpression)
             where TEntity : class
         {
-            var info = new IncludeExpressionInfo(thenIncludeExpression, typeof(TEntity), typeof(TProperty), typeof(TPreviousProperty));
+            if (!previousBuilder.IsChainDiscarded)
+            {
+                var info = new IncludeExpressionInfo(thenIncludeExpression, typeof(TEntity), typeof(TProperty), typeof(TPreviousProperty));
 
-            ((List<IncludeExpressionInfo>)previousBuilder.Specification.IncludeExpressions).Add(info);
+                ((List<IncludeExpressionInfo>)previousBuilder.Specification.IncludeExpressions).Add(info);
+            }
 
-            var includeBuilder = new IncludableSpecificationBuilder<TEntity, TProperty>(previousBuilder.Specification);
+            var includeBuilder = new IncludableSpecificationBuilder<TEntity, TProperty>(previousBuilder.Specification, previousBuilder.IsChainDiscarded);
+
+            return includeBuilder;
+        }
+
+        public static IIncludableSpecificationBuilder<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
+            this IIncludableSpecificationBuilder<TEntity, TPreviousProperty> previousBuilder,
+            Expression<Func<TPreviousProperty, TProperty>> thenIncludeExpression,
+            bool condition)
+            where TEntity : class
+        {
+            if (condition && !previousBuilder.IsChainDiscarded)
+            {
+                var info = new IncludeExpressionInfo(thenIncludeExpression, typeof(TEntity), typeof(TProperty), typeof(TPreviousProperty));
+
+                ((List<IncludeExpressionInfo>)previousBuilder.Specification.IncludeExpressions).Add(info);
+            }
+
+            var includeBuilder = new IncludableSpecificationBuilder<TEntity, TProperty>(previousBuilder.Specification, !condition || previousBuilder.IsChainDiscarded);
 
             return includeBuilder;
         }
@@ -25,11 +46,32 @@ namespace Ardalis.Specification
             Expression<Func<TPreviousProperty, TProperty>> thenIncludeExpression)
             where TEntity : class
         {
-            var info = new IncludeExpressionInfo(thenIncludeExpression, typeof(TEntity), typeof(TProperty), typeof(IEnumerable<TPreviousProperty>));
+            if (!previousBuilder.IsChainDiscarded)
+            {
+                var info = new IncludeExpressionInfo(thenIncludeExpression, typeof(TEntity), typeof(TProperty), typeof(IEnumerable<TPreviousProperty>));
 
-            ((List<IncludeExpressionInfo>)previousBuilder.Specification.IncludeExpressions).Add(info);
+                ((List<IncludeExpressionInfo>)previousBuilder.Specification.IncludeExpressions).Add(info);
+            }
 
-            var includeBuilder = new IncludableSpecificationBuilder<TEntity, TProperty>(previousBuilder.Specification);
+            var includeBuilder = new IncludableSpecificationBuilder<TEntity, TProperty>(previousBuilder.Specification, previousBuilder.IsChainDiscarded);
+
+            return includeBuilder;
+        }
+
+        public static IIncludableSpecificationBuilder<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
+            this IIncludableSpecificationBuilder<TEntity, IEnumerable<TPreviousProperty>> previousBuilder,
+            Expression<Func<TPreviousProperty, TProperty>> thenIncludeExpression,
+            bool condition)
+            where TEntity : class
+        {
+            if (condition && !previousBuilder.IsChainDiscarded)
+            {
+                var info = new IncludeExpressionInfo(thenIncludeExpression, typeof(TEntity), typeof(TProperty), typeof(IEnumerable<TPreviousProperty>));
+
+                ((List<IncludeExpressionInfo>)previousBuilder.Specification.IncludeExpressions).Add(info);
+            }
+
+            var includeBuilder = new IncludableSpecificationBuilder<TEntity, TProperty>(previousBuilder.Specification, !condition || previousBuilder.IsChainDiscarded);
 
             return includeBuilder;
         }

--- a/Specification/src/Ardalis.Specification/Builder/IncludableBuilderExtensions.cs
+++ b/Specification/src/Ardalis.Specification/Builder/IncludableBuilderExtensions.cs
@@ -10,18 +10,7 @@ namespace Ardalis.Specification
             this IIncludableSpecificationBuilder<TEntity, TPreviousProperty> previousBuilder,
             Expression<Func<TPreviousProperty, TProperty>> thenIncludeExpression)
             where TEntity : class
-        {
-            if (!previousBuilder.IsChainDiscarded)
-            {
-                var info = new IncludeExpressionInfo(thenIncludeExpression, typeof(TEntity), typeof(TProperty), typeof(TPreviousProperty));
-
-                ((List<IncludeExpressionInfo>)previousBuilder.Specification.IncludeExpressions).Add(info);
-            }
-
-            var includeBuilder = new IncludableSpecificationBuilder<TEntity, TProperty>(previousBuilder.Specification, previousBuilder.IsChainDiscarded);
-
-            return includeBuilder;
-        }
+            => ThenInclude(previousBuilder, thenIncludeExpression, true);
 
         public static IIncludableSpecificationBuilder<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
             this IIncludableSpecificationBuilder<TEntity, TPreviousProperty> previousBuilder,
@@ -45,18 +34,7 @@ namespace Ardalis.Specification
             this IIncludableSpecificationBuilder<TEntity, IEnumerable<TPreviousProperty>> previousBuilder,
             Expression<Func<TPreviousProperty, TProperty>> thenIncludeExpression)
             where TEntity : class
-        {
-            if (!previousBuilder.IsChainDiscarded)
-            {
-                var info = new IncludeExpressionInfo(thenIncludeExpression, typeof(TEntity), typeof(TProperty), typeof(IEnumerable<TPreviousProperty>));
-
-                ((List<IncludeExpressionInfo>)previousBuilder.Specification.IncludeExpressions).Add(info);
-            }
-
-            var includeBuilder = new IncludableSpecificationBuilder<TEntity, TProperty>(previousBuilder.Specification, previousBuilder.IsChainDiscarded);
-
-            return includeBuilder;
-        }
+            => ThenInclude(previousBuilder, thenIncludeExpression, true);
 
         public static IIncludableSpecificationBuilder<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
             this IIncludableSpecificationBuilder<TEntity, IEnumerable<TPreviousProperty>> previousBuilder,

--- a/Specification/src/Ardalis.Specification/Builder/IncludableSpecificationBuilder.cs
+++ b/Specification/src/Ardalis.Specification/Builder/IncludableSpecificationBuilder.cs
@@ -7,10 +7,17 @@ namespace Ardalis.Specification
     public class IncludableSpecificationBuilder<T, TProperty> : IIncludableSpecificationBuilder<T, TProperty> where T : class
     {
         public Specification<T> Specification { get; }
+        public bool IsChainDiscarded { get; set; }
 
         public IncludableSpecificationBuilder(Specification<T> specification)
+            :this(specification, false)
         {
-            Specification = specification;
+        }
+
+        public IncludableSpecificationBuilder(Specification<T> specification, bool isChainDiscarded)
+        {
+            this.Specification = specification;
+            this.IsChainDiscarded = isChainDiscarded;
         }
     }
 }

--- a/Specification/src/Ardalis.Specification/Builder/OrderedBuilderExtensions.cs
+++ b/Specification/src/Ardalis.Specification/Builder/OrderedBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace Ardalis.Specification
@@ -10,7 +11,27 @@ namespace Ardalis.Specification
             this IOrderedSpecificationBuilder<T> orderedBuilder,
             Expression<Func<T, object?>> orderExpression)
         {
-            ((List<OrderExpressionInfo<T>>)orderedBuilder.Specification.OrderExpressions).Add(new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.ThenBy));
+            if (!orderedBuilder.IsChainDiscarded)
+            {
+                ((List<OrderExpressionInfo<T>>)orderedBuilder.Specification.OrderExpressions).Add(new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.ThenBy));
+            }
+
+            return orderedBuilder;
+        }
+
+        public static IOrderedSpecificationBuilder<T> ThenBy<T>(
+            this IOrderedSpecificationBuilder<T> orderedBuilder,
+            Expression<Func<T, object?>> orderExpression,
+            bool condition)
+        {
+            if (condition && !orderedBuilder.IsChainDiscarded)
+            {
+                ((List<OrderExpressionInfo<T>>)orderedBuilder.Specification.OrderExpressions).Add(new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.ThenBy));
+            }
+            else
+            {
+                orderedBuilder.IsChainDiscarded = true;
+            }
 
             return orderedBuilder;
         }
@@ -19,7 +40,27 @@ namespace Ardalis.Specification
             this IOrderedSpecificationBuilder<T> orderedBuilder,
             Expression<Func<T, object?>> orderExpression)
         {
-            ((List<OrderExpressionInfo<T>>)orderedBuilder.Specification.OrderExpressions).Add(new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.ThenByDescending));
+            if (!orderedBuilder.IsChainDiscarded)
+            {
+                ((List<OrderExpressionInfo<T>>)orderedBuilder.Specification.OrderExpressions).Add(new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.ThenByDescending));
+            }
+
+            return orderedBuilder;
+        }
+
+        public static IOrderedSpecificationBuilder<T> ThenByDescending<T>(
+            this IOrderedSpecificationBuilder<T> orderedBuilder,
+            Expression<Func<T, object?>> orderExpression,
+            bool condition)
+        {
+            if (condition && !orderedBuilder.IsChainDiscarded)
+            {
+                ((List<OrderExpressionInfo<T>>)orderedBuilder.Specification.OrderExpressions).Add(new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.ThenByDescending));
+            }
+            else
+            {
+                orderedBuilder.IsChainDiscarded = true;
+            }
 
             return orderedBuilder;
         }

--- a/Specification/src/Ardalis.Specification/Builder/OrderedBuilderExtensions.cs
+++ b/Specification/src/Ardalis.Specification/Builder/OrderedBuilderExtensions.cs
@@ -10,14 +10,7 @@ namespace Ardalis.Specification
         public static IOrderedSpecificationBuilder<T> ThenBy<T>(
             this IOrderedSpecificationBuilder<T> orderedBuilder,
             Expression<Func<T, object?>> orderExpression)
-        {
-            if (!orderedBuilder.IsChainDiscarded)
-            {
-                ((List<OrderExpressionInfo<T>>)orderedBuilder.Specification.OrderExpressions).Add(new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.ThenBy));
-            }
-
-            return orderedBuilder;
-        }
+            => ThenBy(orderedBuilder, orderExpression, true);
 
         public static IOrderedSpecificationBuilder<T> ThenBy<T>(
             this IOrderedSpecificationBuilder<T> orderedBuilder,
@@ -39,14 +32,7 @@ namespace Ardalis.Specification
         public static IOrderedSpecificationBuilder<T> ThenByDescending<T>(
             this IOrderedSpecificationBuilder<T> orderedBuilder,
             Expression<Func<T, object?>> orderExpression)
-        {
-            if (!orderedBuilder.IsChainDiscarded)
-            {
-                ((List<OrderExpressionInfo<T>>)orderedBuilder.Specification.OrderExpressions).Add(new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.ThenByDescending));
-            }
-
-            return orderedBuilder;
-        }
+            => ThenByDescending(orderedBuilder, orderExpression, true);
 
         public static IOrderedSpecificationBuilder<T> ThenByDescending<T>(
             this IOrderedSpecificationBuilder<T> orderedBuilder,

--- a/Specification/src/Ardalis.Specification/Builder/OrderedSpecificationBuilder.cs
+++ b/Specification/src/Ardalis.Specification/Builder/OrderedSpecificationBuilder.cs
@@ -8,12 +8,17 @@ namespace Ardalis.Specification
     public class OrderedSpecificationBuilder<T> : IOrderedSpecificationBuilder<T>
     {
         public Specification<T> Specification { get; }
+        public bool IsChainDiscarded { get; set; }
 
         public OrderedSpecificationBuilder(Specification<T> specification)
+            :this(specification, false)
         {
-            this.Specification = specification;
         }
 
-
+        public OrderedSpecificationBuilder(Specification<T> specification, bool isChainDiscarded)
+        {
+            this.Specification = specification;
+            this.IsChainDiscarded = isChainDiscarded;
+        }
     }
 }

--- a/Specification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
+++ b/Specification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
@@ -261,5 +261,21 @@ namespace Ardalis.Specification
 
             return specificationBuilder;
         }
+
+        /// <summary>
+        /// The query will ignore the defined global query filters
+        /// </summary>
+        /// <remarks>
+        /// for more info: https://docs.microsoft.com/en-us/ef/core/querying/filters
+        /// </remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="specificationBuilder"></param>
+        public static ISpecificationBuilder<T> IgnoreQueryFilters<T>(
+            this ISpecificationBuilder<T> specificationBuilder) where T : class
+        {
+            specificationBuilder.Specification.IgnoreQueryFilters = true;
+
+            return specificationBuilder;
+        }
     }
 }

--- a/Specification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
+++ b/Specification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
@@ -488,21 +488,5 @@ namespace Ardalis.Specification
 
             return specificationBuilder;
         }
-
-        /// <summary>
-        /// The query will ignore the defined global query filters
-        /// </summary>
-        /// <remarks>
-        /// for more info: https://docs.microsoft.com/en-us/ef/core/querying/filters
-        /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="specificationBuilder"></param>
-        public static ISpecificationBuilder<T> IgnoreQueryFilters<T>(
-            this ISpecificationBuilder<T> specificationBuilder) where T : class
-        {
-            specificationBuilder.Specification.IgnoreQueryFilters = true;
-
-            return specificationBuilder;
-        }
     }
 }

--- a/Specification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
+++ b/Specification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
@@ -15,11 +15,7 @@ namespace Ardalis.Specification
         public static ISpecificationBuilder<T> Where<T>(
             this ISpecificationBuilder<T> specificationBuilder,
             Expression<Func<T, bool>> criteria)
-        {
-            ((List<WhereExpressionInfo<T>>)specificationBuilder.Specification.WhereExpressions).Add(new WhereExpressionInfo<T>(criteria));
-
-            return specificationBuilder;
-        }
+            => Where(specificationBuilder, criteria, true);
 
         /// <summary>
         /// Specify a predicate that will be applied to the query
@@ -50,13 +46,7 @@ namespace Ardalis.Specification
         public static IOrderedSpecificationBuilder<T> OrderBy<T>(
             this ISpecificationBuilder<T> specificationBuilder,
             Expression<Func<T, object?>> orderExpression)
-        {
-            ((List<OrderExpressionInfo<T>>)specificationBuilder.Specification.OrderExpressions).Add(new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.OrderBy));
-
-            var orderedSpecificationBuilder = new OrderedSpecificationBuilder<T>(specificationBuilder.Specification);
-
-            return orderedSpecificationBuilder;
-        }
+            => OrderBy(specificationBuilder, orderExpression, true);
 
         /// <summary>
         /// Specify the query result will be ordered by <paramref name="orderExpression"/> in an ascending order
@@ -89,13 +79,7 @@ namespace Ardalis.Specification
         public static IOrderedSpecificationBuilder<T> OrderByDescending<T>(
             this ISpecificationBuilder<T> specificationBuilder,
             Expression<Func<T, object?>> orderExpression)
-        {
-            ((List<OrderExpressionInfo<T>>)specificationBuilder.Specification.OrderExpressions).Add(new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.OrderByDescending));
-
-            var orderedSpecificationBuilder = new OrderedSpecificationBuilder<T>(specificationBuilder.Specification);
-
-            return orderedSpecificationBuilder;
-        }
+            => OrderByDescending(specificationBuilder, orderExpression, true);
 
         /// <summary>
         /// Specify the query result will be ordered by <paramref name="orderExpression"/> in a descending order
@@ -131,15 +115,7 @@ namespace Ardalis.Specification
         public static IIncludableSpecificationBuilder<T, TProperty> Include<T, TProperty>(
             this ISpecificationBuilder<T> specificationBuilder,
             Expression<Func<T, TProperty>> includeExpression) where T : class
-        {
-            var info = new IncludeExpressionInfo(includeExpression, typeof(T), typeof(TProperty));
-
-            ((List<IncludeExpressionInfo>)specificationBuilder.Specification.IncludeExpressions).Add(info);
-
-            var includeBuilder = new IncludableSpecificationBuilder<T, TProperty>(specificationBuilder.Specification);
-
-            return includeBuilder;
-        }
+            => Include(specificationBuilder, includeExpression, true);
 
         /// <summary>
         /// Specify an include expression.
@@ -177,10 +153,7 @@ namespace Ardalis.Specification
         public static ISpecificationBuilder<T> Include<T>(
             this ISpecificationBuilder<T> specificationBuilder,
             string includeString) where T : class
-        {
-            ((List<string>)specificationBuilder.Specification.IncludeStrings).Add(includeString);
-            return specificationBuilder;
-        }
+            => Include(specificationBuilder, includeString, true);
 
         /// <summary>
         /// Specify a collection of navigation properties, as strings, to include in the query.
@@ -215,11 +188,7 @@ namespace Ardalis.Specification
             Expression<Func<T, string>> selector,
             string searchTerm,
             int searchGroup = 1) where T : class
-        {
-            ((List<SearchExpressionInfo<T>>)specificationBuilder.Specification.SearchCriterias).Add(new SearchExpressionInfo<T>(selector, searchTerm, searchGroup));
-
-            return specificationBuilder;
-        }
+            => Search(specificationBuilder, selector, searchTerm, true, searchGroup);
 
         /// <summary>
         /// Specify a 'SQL LIKE' operations for search purposes
@@ -253,13 +222,7 @@ namespace Ardalis.Specification
         public static ISpecificationBuilder<T> Take<T>(
             this ISpecificationBuilder<T> specificationBuilder,
             int take)
-        {
-            if (specificationBuilder.Specification.Take != null) throw new DuplicateTakeException();
-
-            specificationBuilder.Specification.Take = take;
-            specificationBuilder.Specification.IsPagingEnabled = true;
-            return specificationBuilder;
-        }
+            => Take(specificationBuilder, take, true);
 
         /// <summary>
         /// Specify the number of elements to return.
@@ -292,13 +255,7 @@ namespace Ardalis.Specification
         public static ISpecificationBuilder<T> Skip<T>(
             this ISpecificationBuilder<T> specificationBuilder,
             int skip)
-        {
-            if (specificationBuilder.Specification.Skip != null) throw new DuplicateSkipException();
-
-            specificationBuilder.Specification.Skip = skip;
-            specificationBuilder.Specification.IsPagingEnabled = true;
-            return specificationBuilder;
-        }
+            => Skip(specificationBuilder, skip, true);
 
         /// <summary>
         /// Specify the number of elements to skip before returning the remaining elements.
@@ -381,21 +338,9 @@ namespace Ardalis.Specification
         /// <param name="args">Any arguments used in defining the specification</param>
         public static ICacheSpecificationBuilder<T> EnableCache<T>(
             this ISpecificationBuilder<T> specificationBuilder,
-            string specificationName, params object[] args) where T : class
-        {
-            if (string.IsNullOrEmpty(specificationName))
-            {
-                throw new ArgumentException($"Required input {specificationName} was null or empty.", specificationName);
-            }
-
-            specificationBuilder.Specification.CacheKey = $"{specificationName}-{string.Join("-", args)}";
-
-            specificationBuilder.Specification.CacheEnabled = true;
-
-            var cacheBuilder = new CacheSpecificationBuilder<T>(specificationBuilder.Specification);
-
-            return cacheBuilder;
-        }
+            string specificationName,
+            params object[] args) where T : class
+            => EnableCache(specificationBuilder, specificationName, true, args);
 
         /// <summary>
         /// Must be called after specifying criteria
@@ -433,11 +378,7 @@ namespace Ardalis.Specification
         /// <param name="specificationBuilder"></param>
         public static ISpecificationBuilder<T> AsNoTracking<T>(
             this ISpecificationBuilder<T> specificationBuilder) where T : class
-        {
-            specificationBuilder.Specification.AsNoTracking = true;
-
-            return specificationBuilder;
-        }
+            => AsNoTracking(specificationBuilder, true);
 
         /// <summary>
         /// If the entity instances are modified, this will not be detected
@@ -468,11 +409,7 @@ namespace Ardalis.Specification
         /// <param name="specificationBuilder"></param>
         public static ISpecificationBuilder<T> AsSplitQuery<T>(
             this ISpecificationBuilder<T> specificationBuilder) where T : class
-        {
-            specificationBuilder.Specification.AsSplitQuery = true;
-
-            return specificationBuilder;
-        }
+            => AsSplitQuery(specificationBuilder, true);
 
         /// <summary>
         /// The generated sql query will be split into multiple SQL queries
@@ -508,11 +445,7 @@ namespace Ardalis.Specification
         /// <param name="specificationBuilder"></param>
         public static ISpecificationBuilder<T> AsNoTrackingWithIdentityResolution<T>(
             this ISpecificationBuilder<T> specificationBuilder) where T : class
-        {
-            specificationBuilder.Specification.AsNoTrackingWithIdentityResolution = true;
-
-            return specificationBuilder;
-        }
+            => AsNoTrackingWithIdentityResolution(specificationBuilder, true);
 
         /// <summary>
         /// The query will then keep track of returned instances 
@@ -547,11 +480,7 @@ namespace Ardalis.Specification
         /// <param name="specificationBuilder"></param>
         public static ISpecificationBuilder<T> IgnoreQueryFilters<T>(
             this ISpecificationBuilder<T> specificationBuilder) where T : class
-        {
-            specificationBuilder.Specification.IgnoreQueryFilters = true;
-
-            return specificationBuilder;
-        }
+            => IgnoreQueryFilters(specificationBuilder, true);
 
         /// <summary>
         /// The query will ignore the defined global query filters

--- a/Specification/src/Ardalis.Specification/ISpecification.cs
+++ b/Specification/src/Ardalis.Specification/ISpecification.cs
@@ -113,6 +113,14 @@ namespace Ardalis.Specification
         bool AsNoTrackingWithIdentityResolution { get; }
 
         /// <summary>
+        /// Returns whether or not the query should ignore the defined global query filters 
+        /// </summary>
+        /// <remarks>
+        /// for more info: https://docs.microsoft.com/en-us/ef/core/querying/filters
+        /// </remarks>
+        bool IgnoreQueryFilters { get; }
+
+        /// <summary>
         /// Applies the query defined within the specification to the given objects.
         /// This is specially helpful when unit testing specification classes
         /// </summary>

--- a/Specification/src/Ardalis.Specification/ISpecification.cs
+++ b/Specification/src/Ardalis.Specification/ISpecification.cs
@@ -127,5 +127,12 @@ namespace Ardalis.Specification
         /// <param name="entities">the list of entities to which the specification will be applied</param>
         /// <returns></returns>
         IEnumerable<T> Evaluate(IEnumerable<T> entities);
+
+        /// <summary>
+        /// It returns whether the given entity satisfies the conditions of the specification.
+        /// </summary>
+        /// <param name="entity">The entity to be validated</param>
+        /// <returns></returns>
+        bool IsSatisfiedBy(T entity);
     }
 }

--- a/Specification/src/Ardalis.Specification/Specification.cs
+++ b/Specification/src/Ardalis.Specification/Specification.cs
@@ -39,7 +39,7 @@ namespace Ardalis.Specification
         protected virtual ISpecificationBuilder<T> Query { get; }
 
         protected Specification()
-            : this(InMemorySpecificationEvaluator.Default)
+            : this(InMemorySpecificationEvaluator.Default, SpecificationValidator.Default)
         {
         }
 

--- a/Specification/src/Ardalis.Specification/Specification.cs
+++ b/Specification/src/Ardalis.Specification/Specification.cs
@@ -94,5 +94,8 @@ namespace Ardalis.Specification
 
         /// <inheritdoc/>
         public bool AsNoTrackingWithIdentityResolution { get; internal set; } = false;
+
+        /// <inheritdoc/>
+        public bool IgnoreQueryFilters { get; internal set; } = false;
     }
 }

--- a/Specification/src/Ardalis.Specification/Specification.cs
+++ b/Specification/src/Ardalis.Specification/Specification.cs
@@ -35,6 +35,7 @@ namespace Ardalis.Specification
     public abstract class Specification<T> : ISpecification<T>
     {
         protected IInMemorySpecificationEvaluator Evaluator { get; }
+        protected ISpecificationValidator Validator { get; }
         protected virtual ISpecificationBuilder<T> Query { get; }
 
         protected Specification()
@@ -43,8 +44,19 @@ namespace Ardalis.Specification
         }
 
         protected Specification(IInMemorySpecificationEvaluator inMemorySpecificationEvaluator)
+            : this(inMemorySpecificationEvaluator, SpecificationValidator.Default)
+        {
+        }
+
+        protected Specification(ISpecificationValidator specificationValidator)
+            : this(InMemorySpecificationEvaluator.Default, specificationValidator)
+        {
+        }
+
+        protected Specification(IInMemorySpecificationEvaluator inMemorySpecificationEvaluator, ISpecificationValidator specificationValidator)
         {
             this.Evaluator = inMemorySpecificationEvaluator;
+            this.Validator = specificationValidator;
             this.Query = new SpecificationBuilder<T>(this);
         }
 
@@ -52,6 +64,12 @@ namespace Ardalis.Specification
         public virtual IEnumerable<T> Evaluate(IEnumerable<T> entities)
         {
             return Evaluator.Evaluate(entities, this);
+        }
+
+        /// <inheritdoc/>
+        public virtual bool IsSatisfiedBy(T entity)
+        {
+            return Validator.IsValid(entity, this);
         }
 
         /// <inheritdoc/>

--- a/Specification/src/Ardalis.Specification/Validators/ISpecificationValidator.cs
+++ b/Specification/src/Ardalis.Specification/Validators/ISpecificationValidator.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ardalis.Specification
+{
+    public interface ISpecificationValidator
+    {
+        bool IsValid<T>(T entity, ISpecification<T> specification);
+    }
+}

--- a/Specification/src/Ardalis.Specification/Validators/IValidator.cs
+++ b/Specification/src/Ardalis.Specification/Validators/IValidator.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ardalis.Specification
+{
+    public interface IValidator
+    {
+        bool IsValid<T>(T entity, ISpecification<T> specification);
+    }
+}

--- a/Specification/src/Ardalis.Specification/Validators/SearchValidator.cs
+++ b/Specification/src/Ardalis.Specification/Validators/SearchValidator.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Ardalis.Specification
+{
+    public class SearchValidator : IValidator
+    {
+        private SearchValidator() { }
+        public static SearchValidator Instance { get; } = new SearchValidator();
+
+        public bool IsValid<T>(T entity, ISpecification<T> specification)
+        {
+            foreach (var searchGroup in specification.SearchCriterias.GroupBy(x => x.SearchGroup))
+            {
+                if (searchGroup.Any(c => c.SelectorFunc(entity).Like(c.SearchTerm)) == false) return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Specification/src/Ardalis.Specification/Validators/SpecificationValidator.cs
+++ b/Specification/src/Ardalis.Specification/Validators/SpecificationValidator.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ardalis.Specification
+{
+    public class SpecificationValidator : ISpecificationValidator
+    {
+        // Will use singleton for default configuration. Yet, it can be instantiated if necessary, with default or provided validators.
+        public static SpecificationValidator Default { get; } = new SpecificationValidator();
+
+        private readonly List<IValidator> validators = new List<IValidator>();
+
+        public SpecificationValidator()
+        {
+            this.validators.AddRange(new IValidator[]
+            {
+                WhereValidator.Instance,
+                SearchValidator.Instance
+            });
+        }
+        public SpecificationValidator(IEnumerable<IValidator> validators)
+        {
+            this.validators.AddRange(validators);
+        }
+
+        public virtual bool IsValid<T>(T entity, ISpecification<T> specification)
+        {
+            foreach (var partialValidator in validators)
+            {
+                if (partialValidator.IsValid(entity, specification) == false) return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Specification/src/Ardalis.Specification/Validators/WhereValidator.cs
+++ b/Specification/src/Ardalis.Specification/Validators/WhereValidator.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ardalis.Specification
+{
+    public class WhereValidator : IValidator
+    {
+        private WhereValidator() { }
+        public static WhereValidator Instance { get; } = new WhereValidator();
+
+        public bool IsValid<T>(T entity, ISpecification<T> specification)
+        {
+            foreach (var info in specification.WhereExpressions)
+            {
+                if (info.FilterFunc(entity) == false) return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/IncludableBuilderExtensions_ThenInclude.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/IncludableBuilderExtensions_ThenInclude.cs
@@ -23,6 +23,24 @@ namespace Ardalis.Specification.UnitTests
         }
 
         [Fact]
+        public void AddsNothingToList_GivenDiscardedIncludeChain()
+        {
+            var spec = new CompanyByIdWithFalseConditions(1);
+
+            spec.IncludeExpressions.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void AddsNothingToList_GivenThenIncludeExpressionWithFalseCondition()
+        {
+            var spec = new CompanyByIdWithFalseConditionsForInnerChains(1);
+
+            spec.IncludeExpressions.Should().HaveCount(1);
+            spec.IncludeExpressions.First().Type.Should().Be(IncludeTypeEnum.Include);
+            spec.IncludeExpressions.Where(x => x.Type == IncludeTypeEnum.ThenInclude).Should().BeEmpty();
+        }
+
+        [Fact]
         public void ThenInclude_Append_IncludeExpressionInfo_With_EnumerablePreviousPropertyType()
         {
             var spec = new StoreIncludeCompanyThenStoresSpec();

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/OrderedBuilderExtensions_ThenBy.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/OrderedBuilderExtensions_ThenBy.cs
@@ -23,5 +23,24 @@ namespace Ardalis.Specification.UnitTests
 
             orderExpressions[1].OrderType.Should().Be(OrderTypeEnum.ThenBy);
         }
+
+        [Fact]
+        public void AddsNothingToList_GivenDiscardedOrderChain()
+        {
+            var spec = new CompanyByIdWithFalseConditions(1);
+
+            spec.OrderExpressions.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void AddsNothingToList_GivenThenByExpressionWithFalseCondition()
+        {
+            var spec = new CompanyByIdWithFalseConditionsForInnerChains(1);
+
+            spec.OrderExpressions.Should().HaveCount(2);
+            spec.OrderExpressions.First().OrderType.Should().Be(OrderTypeEnum.OrderBy);
+            spec.OrderExpressions.Skip(1).First().OrderType.Should().Be(OrderTypeEnum.OrderByDescending);
+            spec.OrderExpressions.Where(x => x.OrderType == OrderTypeEnum.ThenBy).Should().BeEmpty();
+        }
     }
 }

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/OrderedBuilderExtensions_ThenByDescending.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/OrderedBuilderExtensions_ThenByDescending.cs
@@ -23,5 +23,24 @@ namespace Ardalis.Specification.UnitTests
 
             orderExpressions[1].OrderType.Should().Be(OrderTypeEnum.ThenByDescending);
         }
+
+        [Fact]
+        public void AddsNothingToList_GivenDiscardedOrderChain()
+        {
+            var spec = new CompanyByIdWithFalseConditions(1);
+
+            spec.OrderExpressions.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void AddsNothingToList_GivenThenByDescendingExpressionWithFalseCondition()
+        {
+            var spec = new CompanyByIdWithFalseConditionsForInnerChains(1);
+
+            spec.OrderExpressions.Should().HaveCount(2);
+            spec.OrderExpressions.First().OrderType.Should().Be(OrderTypeEnum.OrderBy);
+            spec.OrderExpressions.Skip(1).First().OrderType.Should().Be(OrderTypeEnum.OrderByDescending);
+            spec.OrderExpressions.Where(x => x.OrderType == OrderTypeEnum.ThenByDescending).Should().BeEmpty();
+        }
     }
 }

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_AsNoTracking.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_AsNoTracking.cs
@@ -15,6 +15,14 @@ namespace Ardalis.Specification.UnitTests.BuilderTests
         }
 
         [Fact]
+        public void DoesNothing_GivenAsNoTrackingWithFalseCondition()
+        {
+            var spec = new CompanyByIdWithFalseConditions(1);
+
+            spec.AsNoTracking.Should().Be(false);
+        }
+
+        [Fact]
         public void FlagsAsNoTracking_GivenSpecWithAsNoTracking()
         {
             var spec = new CompanyByIdAsUntrackedSpec(1);

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_AsNoTrackingWithIdentityResolution.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_AsNoTrackingWithIdentityResolution.cs
@@ -7,7 +7,7 @@ namespace Ardalis.Specification.UnitTests.BuilderTests
     public class SpecificationBuilderExtensions_AsNoTrackingWithIdentityResolution
     {
         [Fact]
-        public void DoesNothing_GivenSpecWithoutAsNoTracking()
+        public void DoesNothing_GivenSpecWithoutAsNoTrackingWithIdentityResolution()
         {
             var spec = new StoreEmptySpec();
 
@@ -15,7 +15,15 @@ namespace Ardalis.Specification.UnitTests.BuilderTests
         }
 
         [Fact]
-        public void FlagsAsNoTracking_GivenSpecWithAsNoTracking()
+        public void DoesNothing_GivenAsNoTrackingWithIdentityResolutionWithFalseCondition()
+        {
+            var spec = new CompanyByIdWithFalseConditions(1);
+
+            spec.AsNoTrackingWithIdentityResolution.Should().Be(false);
+        }
+
+        [Fact]
+        public void FlagsAsNoTracking_GivenSpecWithAsNoTrackingWithIdentityResolution()
         {
             var spec = new CompanyByIdAsUntrackedWithIdentityResolutionSpec(1);
 

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_AsSplitQuery.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_AsSplitQuery.cs
@@ -1,0 +1,33 @@
+﻿using Ardalis.Specification.UnitTests.Fixture.Specs;
+using FluentAssertions;
+using Xunit;
+
+namespace Ardalis.Specification.UnitTests.BuilderTests
+{
+    public class SpecificationBuilderExtensions_AsSplitQuery
+    {
+        [Fact]
+        public void DoesNothing_GivenSpecWithoutAsSplitQuery()
+        {
+            var spec = new StoreEmptySpec();
+
+            spec.AsSplitQuery.Should().Be(false);
+        }
+
+        [Fact]
+        public void DoesNothing_GivenAsSplitQueryWithFalseCondition()
+        {
+            var spec = new CompanyByIdWithFalseConditions(1);
+
+            spec.AsSplitQuery.Should().Be(false);
+        }
+
+        [Fact]
+        public void FlagsAsNoTracking_GivenSpecWithAsSplitQuery()
+        {
+            var spec = new CompanyByIdAsSplitQuery(1);
+
+            spec.AsSplitQuery.Should().Be(true);
+        }
+    }
+}

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_IgnoreQueryFilters.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_IgnoreQueryFilters.cs
@@ -1,0 +1,25 @@
+﻿using Ardalis.Specification.UnitTests.Fixture.Specs;
+using FluentAssertions;
+using Xunit;
+
+namespace Ardalis.Specification.UnitTests.BuilderTests
+{
+    public class SpecificationBuilderExtensions_IgnoreQueryFilters
+    {
+        [Fact]
+        public void DoesNothing_GivenSpecWithoutIgnoreQueryFilters()
+        {
+            var spec = new StoreEmptySpec();
+
+            spec.IgnoreQueryFilters.Should().Be(false);
+        }
+
+        [Fact]
+        public void FlagsIgnoreQueryFilters_GivenSpecWithIgnoreQueryFilters()
+        {
+            var spec = new CompanyByIdIgnoreQueryFilters(1);
+
+            spec.IgnoreQueryFilters.Should().Be(true);
+        }
+    }
+}

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_IgnoreQueryFilters.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_IgnoreQueryFilters.cs
@@ -15,6 +15,14 @@ namespace Ardalis.Specification.UnitTests.BuilderTests
         }
 
         [Fact]
+        public void DoesNothing_GivenIgnoreQueryFiltersWithFalseCondition()
+        {
+            var spec = new CompanyByIdWithFalseConditions(1);
+
+            spec.IgnoreQueryFilters.Should().Be(false);
+        }
+
+        [Fact]
         public void FlagsIgnoreQueryFilters_GivenSpecWithIgnoreQueryFilters()
         {
             var spec = new CompanyByIdIgnoreQueryFilters(1);

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_Include.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_Include.cs
@@ -20,6 +20,14 @@ namespace Ardalis.Specification.UnitTests
         }
 
         [Fact]
+        public void AddsNothingToList_GivenIncludeExpressionWithFalseCondition()
+        {
+            var spec = new CompanyByIdWithFalseConditions(1);
+
+            spec.IncludeExpressions.Should().BeEmpty();
+        }
+
+        [Fact]
         public void AddsIncludeExpressionInfoToListWithTypeInclude_GivenIncludeExpression()
         {
             var spec = new StoreIncludeAddressSpec();

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_IncludeString.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_IncludeString.cs
@@ -20,6 +20,14 @@ namespace Ardalis.Specification.UnitTests
         }
 
         [Fact]
+        public void AddsNothingToList_GivenIncludeStringWithFalseCondition()
+        {
+            var spec = new CompanyByIdWithFalseConditions(1);
+
+            spec.IncludeStrings.Should().BeEmpty();
+        }
+
+        [Fact]
         public void AddsIncludeStringToList_GivenString()
         {
             var spec = new StoreIncludeCompanyThenCountryAsStringSpec();

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_OrderBy.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_OrderBy.cs
@@ -20,6 +20,14 @@ namespace Ardalis.Specification.UnitTests
         }
 
         [Fact]
+        public void AddsNothingToList_GivenOrderExpressionWithFalseCondition()
+        {
+            var spec = new CompanyByIdWithFalseConditions(1);
+
+            spec.OrderExpressions.Should().BeEmpty();
+        }
+
+        [Fact]
         public void AddsOrderExpressionToListWithOrderByType_GivenOrderByExpression()
         {
             var spec = new StoresOrderedSpecByName();

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_OrderByDescending.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_OrderByDescending.cs
@@ -20,6 +20,14 @@ namespace Ardalis.Specification.UnitTests
         }
 
         [Fact]
+        public void AddsNothingToList_GivenOrderExpressionWithFalseCondition()
+        {
+            var spec = new CompanyByIdWithFalseConditions(1);
+
+            spec.OrderExpressions.Should().BeEmpty();
+        }
+
+        [Fact]
         public void AddsOrderExpressionToListWithOrderByDescendingType_GivenOrderByDescendingExpression()
         {
             var spec = new StoresOrderedDescendingByNameSpec();

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_Search.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_Search.cs
@@ -20,6 +20,14 @@ namespace Ardalis.Specification.UnitTests
         }
 
         [Fact]
+        public void AddsNothingToList_GivenSearchExpressionWithFalseCondition()
+        {
+            var spec = new CompanyByIdWithFalseConditions(1);
+
+            spec.SearchCriterias.Should().BeEmpty();
+        }
+
+        [Fact]
         public void AddsOneCriteriaWithDefaultGroupToList_GivenOneSearchExpressionWithNoGroup()
         {
             var spec = new StoreSearchByNameSpec("test");

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_Skip.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_Skip.cs
@@ -23,6 +23,15 @@ namespace Ardalis.Specification.UnitTests
         }
 
         [Fact]
+        public void DoesNothing_GivenSkipWithFalseCondition()
+        {
+            var spec = new CompanyByIdWithFalseConditions(1);
+
+            spec.Skip.Should().BeNull();
+            spec.IsPagingEnabled.Should().BeFalse();
+        }
+
+        [Fact]
         public void ThrowsDuplicateSkipException_GivenSkipUsedMoreThanOnce()
         {
             Assert.Throws<DuplicateSkipException>(() => new StoreDuplicateSkipSpec());

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_Skip.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_Skip.cs
@@ -26,7 +26,6 @@ namespace Ardalis.Specification.UnitTests
             var spec = new CompanyByIdWithFalseConditions(1);
 
             spec.Skip.Should().BeNull();
-            spec.IsPagingEnabled.Should().BeFalse();
         }
 
         [Fact]

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_Take.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_Take.cs
@@ -22,6 +22,15 @@ namespace Ardalis.Specification.UnitTests
         }
 
         [Fact]
+        public void DoesNothing_GivenTakeWithFalseCondition()
+        {
+            var spec = new CompanyByIdWithFalseConditions(1);
+
+            spec.Take.Should().BeNull();
+            spec.IsPagingEnabled.Should().BeFalse();
+        }
+
+        [Fact]
         public void ThrowsDuplicateTakeException_GivenTakeUsedMoreThanOnce()
         {
             Assert.Throws<DuplicateTakeException>(() => new StoreDuplicateTakeSpec());

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_Take.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_Take.cs
@@ -24,7 +24,6 @@ namespace Ardalis.Specification.UnitTests
             var spec = new CompanyByIdWithFalseConditions(1);
 
             spec.Take.Should().BeNull();
-            spec.IsPagingEnabled.Should().BeFalse();
         }
 
         [Fact]

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_Where.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_Where.cs
@@ -20,6 +20,14 @@ namespace Ardalis.Specification.UnitTests
         }
 
         [Fact]
+        public void AddsNothingToList_GivenWhereExpressionWithFalseCondition()
+        {
+            var spec = new CompanyByIdWithFalseConditions(1);
+
+            spec.WhereExpressions.Should().BeEmpty();
+        }
+
+        [Fact]
         public void AddsOneExpressionToList_GivenOneWhereExpression()
         {
             var spec = new StoreByIdSpec(1);

--- a/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Entities/Seeds/StoreSeed.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Entities/Seeds/StoreSeed.cs
@@ -11,8 +11,10 @@ namespace Ardalis.Specification.UnitTests.Fixture.Entities.Seeds
         public const string VALID_STORE_NAME = "Store 1";
         public const string VALID_STORE_City = "City 1";
 
-        public const int VALID_Search_City_ID = 50;
+        public const int VALID_Search_ID = 50;
         public const string VALID_Search_City_Key = "BCD";
+        public const string VALID_Search_Name_Key = "BCE";
+        public const string VALID_Search_City_Name_Key = "BC";
 
 
         public const int ORDERED_BY_NAME_FIRST_ID = 48;
@@ -62,6 +64,7 @@ namespace Ardalis.Specification.UnitTests.Fixture.Entities.Seeds
             stores[100 - 1].Name = "Store 999";
 
             stores[50 - 1].City = "ABCDEFGH";
+            stores[50 - 1].Name = "ABCEFGH";
 
             return stores;
         }

--- a/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/CompanyByIdAsSplitQuery.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/CompanyByIdAsSplitQuery.cs
@@ -1,0 +1,18 @@
+﻿using Ardalis.Specification.UnitTests.Fixture.Entities;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ardalis.Specification.UnitTests.Fixture.Specs
+{
+    public class CompanyByIdAsSplitQuery : Specification<Company>, ISingleResultSpecification
+    {
+        public CompanyByIdAsSplitQuery(int id)
+        {
+            Query.Where(company => company.Id == id)
+                .Include(x=>x.Stores)
+                .ThenInclude(x=>x.Products)
+                .AsSplitQuery();
+        }
+    }
+}

--- a/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/CompanyByIdIgnoreQueryFilters.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/CompanyByIdIgnoreQueryFilters.cs
@@ -1,0 +1,15 @@
+﻿using Ardalis.Specification.UnitTests.Fixture.Entities;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ardalis.Specification.UnitTests.Fixture.Specs
+{
+    public class CompanyByIdIgnoreQueryFilters : Specification<Company>, ISingleResultSpecification
+    {
+        public CompanyByIdIgnoreQueryFilters(int id)
+        {
+            Query.Where(company => company.Id == id).IgnoreQueryFilters();
+        }
+    }
+}

--- a/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/CompanyByIdWithFalseConditions.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/CompanyByIdWithFalseConditions.cs
@@ -1,0 +1,32 @@
+﻿using Ardalis.Specification.UnitTests.Fixture.Entities;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ardalis.Specification.UnitTests.Fixture.Specs
+{
+    public class CompanyByIdWithFalseConditions : Specification<Company>, ISingleResultSpecification
+    {
+        public CompanyByIdWithFalseConditions(int id)
+        {
+            Query.Where(x => x.Id == id, false)
+                .OrderBy(x => x.Id, false)
+                    .ThenBy(x => x.Name)
+                    .ThenByDescending(x => x.Name)
+                .OrderByDescending(x => x.Id, false)
+                    .ThenBy(x => x.Name)
+                    .ThenByDescending(x => x.Name)
+                .Include(x => x.Stores, false)
+                    .ThenInclude(x => x.Products)
+                .Include(nameof(Store), false)
+                .Take(10, false)
+                .Skip(10, false)
+                .AsNoTracking(false)
+                .AsNoTrackingWithIdentityResolution(false)
+                .AsSplitQuery(false)
+                .IgnoreQueryFilters(false)
+                .Search(x => x.Name!, "asd", false)
+                .EnableCache(nameof(CompanyByIdWithFalseConditions), false, id);
+        }
+    }
+}

--- a/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/CompanyByIdWithFalseConditionsForInnerChains.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/CompanyByIdWithFalseConditionsForInnerChains.cs
@@ -1,0 +1,33 @@
+﻿using Ardalis.Specification.UnitTests.Fixture.Entities;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ardalis.Specification.UnitTests.Fixture.Specs
+{
+    public class CompanyByIdWithFalseConditionsForInnerChains : Specification<Company>, ISingleResultSpecification
+    {
+        public CompanyByIdWithFalseConditionsForInnerChains(int id)
+        {
+            Query.Where(x => x.Id == id, false)
+                .OrderBy(x => x.Id)
+                    .ThenBy(x => x.Name, false)
+                    .ThenByDescending(x => x.Name)
+                .OrderByDescending(x => x.Id)
+                    .ThenByDescending(x => x.Name, false)
+                    .ThenBy(x => x.Name)
+                .Include(x => x.Stores)
+                    .ThenInclude(x => x.Products, false)
+                    .ThenInclude(x => x.Store)
+                .Include(nameof(Store), false)
+                .Take(10, false)
+                .Skip(10, false)
+                .AsNoTracking(false)
+                .AsNoTrackingWithIdentityResolution(false)
+                .AsSplitQuery(false)
+                .IgnoreQueryFilters(false)
+                .Search(x => x.Name!, "asd", false)
+                .EnableCache(nameof(CompanyByIdWithFalseConditions), false, id);
+        }
+    }
+}

--- a/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/StoreByIdSearchByNameAndCitySpec.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/StoreByIdSearchByNameAndCitySpec.cs
@@ -1,0 +1,17 @@
+﻿using Ardalis.Specification.UnitTests.Fixture.Entities;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ardalis.Specification.UnitTests.Fixture.Specs
+{
+    public class StoreByIdSearchByNameAndCitySpec : Specification<Store>
+    {
+        public StoreByIdSearchByNameAndCitySpec(int id, string searchTerm)
+        {
+            Query.Where(x=> x.Id == id)
+                .Search(x => x.Name!, "%" + searchTerm + "%", 1)
+                .Search(x => x.City!, "%" + searchTerm + "%", 2);
+        }
+    }
+}

--- a/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/StoreByIdSearchByNameOrCitySpec.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/StoreByIdSearchByNameOrCitySpec.cs
@@ -1,0 +1,17 @@
+﻿using Ardalis.Specification.UnitTests.Fixture.Entities;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ardalis.Specification.UnitTests.Fixture.Specs
+{
+    public class StoreByIdSearchByNameOrCitySpec : Specification<Store>
+    {
+        public StoreByIdSearchByNameOrCitySpec(int id, string searchTerm)
+        {
+            Query.Where(x => x.Id == id)
+                .Search(x => x.Name!, "%" + searchTerm + "%")
+                .Search(x => x.City!, "%" + searchTerm + "%");
+        }
+    }
+}

--- a/Specification/tests/Ardalis.Specification.UnitTests/ValidatorTests/SpecificationValidator_Tests.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/ValidatorTests/SpecificationValidator_Tests.cs
@@ -1,0 +1,98 @@
+﻿using Ardalis.Specification.UnitTests.Fixture.Entities;
+using Ardalis.Specification.UnitTests.Fixture.Entities.Seeds;
+using Ardalis.Specification.UnitTests.Fixture.Specs;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ardalis.Specification.UnitTests.ValidatorTests
+{
+    public class SpecificationValidator_Tests
+    {
+        Store store = StoreSeed.Get().Single(x => x.Id == StoreSeed.VALID_Search_ID);
+
+        public void ReturnsTrue_GivenStoreByIdSearchByNameAndCitySpec_WithValidValues()
+        {
+            var spec = new StoreByIdSearchByNameAndCitySpec(StoreSeed.VALID_Search_ID, StoreSeed.VALID_Search_City_Name_Key);
+
+            var result = spec.IsSatisfiedBy(store);
+
+            result.Should().BeTrue();
+        }
+
+        public void ReturnsFalse_GivenStoreByIdSearchByNameAndCitySpec_WithInvalidId()
+        {
+            var spec = new StoreByIdSearchByNameAndCitySpec(1, StoreSeed.VALID_Search_City_Name_Key);
+
+            var result = spec.IsSatisfiedBy(store);
+
+            result.Should().BeFalse();
+        }
+
+        public void ReturnsFalse_GivenStoreByIdSearchByNameAndCitySpec_WithInvalidNameSearchString()
+        {
+            var spec = new StoreByIdSearchByNameAndCitySpec(StoreSeed.VALID_Search_ID, StoreSeed.VALID_Search_City_Key);
+
+            var result = spec.IsSatisfiedBy(store);
+
+            result.Should().BeFalse();
+        }
+
+        public void ReturnsFalse_GivenStoreByIdSearchByNameAndCitySpec_WithInvalidCitySearchString()
+        {
+            var spec = new StoreByIdSearchByNameAndCitySpec(StoreSeed.VALID_Search_ID, StoreSeed.VALID_Search_Name_Key);
+
+            var result = spec.IsSatisfiedBy(store);
+
+            result.Should().BeFalse();
+        }
+
+        public void ReturnsFalse_StoreByIdSearchByNameAndCitySpecSpec_WithInvalidCityAndNameSearchString()
+        {
+            var spec = new StoreByIdSearchByNameAndCitySpec(StoreSeed.VALID_Search_ID, "random");
+
+            var result = spec.IsSatisfiedBy(store);
+
+            result.Should().BeFalse();
+        }
+
+        public void ReturnsTrue_StoreByIdSearchByNameOrCitySpecSpec_WithValidValues()
+        {
+            var spec = new StoreByIdSearchByNameOrCitySpec(StoreSeed.VALID_Search_ID, StoreSeed.VALID_Search_City_Name_Key);
+
+            var result = spec.IsSatisfiedBy(store);
+
+            result.Should().BeTrue();
+        }
+
+        public void ReturnsTrue_StoreByIdSearchByNameOrCitySpecSpec_WithInvalidNameSearchString()
+        {
+            var spec = new StoreByIdSearchByNameOrCitySpec(StoreSeed.VALID_Search_ID, StoreSeed.VALID_Search_City_Key);
+
+            var result = spec.IsSatisfiedBy(store);
+
+            result.Should().BeTrue();
+        }
+
+        public void ReturnsTrue_StoreByIdSearchByNameOrCitySpecSpec_WithInvalidCitySearchString()
+        {
+            var spec = new StoreByIdSearchByNameOrCitySpec(StoreSeed.VALID_Search_ID, StoreSeed.VALID_Search_Name_Key);
+
+            var result = spec.IsSatisfiedBy(store);
+
+            result.Should().BeTrue();
+        }
+
+        public void ReturnsFalse_StoreByIdSearchByNameOrCitySpecSpec_WithInvalidCityAndNameSearchString()
+        {
+            var spec = new StoreByIdSearchByNameOrCitySpec(StoreSeed.VALID_Search_ID, "random");
+
+            var result = spec.IsSatisfiedBy(store);
+
+            result.Should().BeFalse();
+        }
+    }
+}


### PR DESCRIPTION
Closes #111. This should be merged after PR #192.

This feature offers the possibility to check if an entity satisfies the conditions in a given specification. Since it's a single entity, it's being validated only against expressions/conditions specified in `Where` and `Search`, and everything else is omitted during this process. The usage is quite simple

```c#
var customer = new Customer { Name = "something" };
var spec = new CustomerByNameSpec("something");
var result = spec.IsSatisfiedBy(customer)
```

The implementation uses a separate infrastructure for this feature, by introducing new constructs `ISpecificationValidator` and `IValidator` (partial validator). I decided not to use the in-memory evaluators, since we'll force omitted evaluators to implement `IsValid()`, which is not nice. 