### PR TITLE
Move the selector checks to the evaluators.

### DIFF
--- a/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Evaluators/SpecificationEvaluator.cs
+++ b/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Evaluators/SpecificationEvaluator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Ardalis.Specification.EntityFramework6
@@ -31,6 +32,9 @@ namespace Ardalis.Specification.EntityFramework6
         /// <inheritdoc/>
         public virtual IQueryable<TResult> GetQuery<T, TResult>(IQueryable<T> query, ISpecification<T, TResult> specification) where T : class
         {
+            if (specification is null) throw new ArgumentNullException("Specification is required");
+            if (specification.Selector is null) throw new SelectorNotFoundException();
+
             query = GetQuery(query, (ISpecification<T>)specification);
 
             return query.Select(specification.Selector);
@@ -39,6 +43,8 @@ namespace Ardalis.Specification.EntityFramework6
         /// <inheritdoc/>
         public virtual IQueryable<T> GetQuery<T>(IQueryable<T> query, ISpecification<T> specification, bool evaluateCriteriaOnly = false) where T : class
         {
+            if (specification is null) throw new ArgumentNullException("Specification is required");
+
             var evaluators = evaluateCriteriaOnly ? this.evaluators.Where(x => x.IsCriteriaEvaluator) : this.evaluators;
 
             foreach (var evaluator in evaluators)

--- a/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/RepositoryBaseOfT.cs
+++ b/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/RepositoryBaseOfT.cs
@@ -143,9 +143,6 @@ namespace Ardalis.Specification.EntityFramework6
         /// <returns>The filtered projected entities as an <see cref="IQueryable{T}"/>.</returns>
         protected virtual IQueryable<TResult> ApplySpecification<TResult>(ISpecification<T, TResult> specification)
         {
-            if (specification is null) throw new ArgumentNullException("Specification is required");
-            if (specification.Selector is null) throw new SelectorNotFoundException();
-
             return specificationEvaluator.GetQuery(dbContext.Set<T>().AsQueryable(), specification);
         }
     }

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SpecificationEvaluator.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SpecificationEvaluator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Ardalis.Specification.EntityFrameworkCore
@@ -45,6 +46,9 @@ namespace Ardalis.Specification.EntityFrameworkCore
         /// <inheritdoc/>
         public virtual IQueryable<TResult> GetQuery<T, TResult>(IQueryable<T> query, ISpecification<T, TResult> specification) where T : class
         {
+            if (specification is null) throw new ArgumentNullException("Specification is required");
+            if (specification.Selector is null) throw new SelectorNotFoundException();
+
             query = GetQuery(query, (ISpecification<T>)specification);
 
             return query.Select(specification.Selector);
@@ -53,6 +57,8 @@ namespace Ardalis.Specification.EntityFrameworkCore
         /// <inheritdoc/>
         public virtual IQueryable<T> GetQuery<T>(IQueryable<T> query, ISpecification<T> specification, bool evaluateCriteriaOnly = false) where T : class
         {
+            if (specification is null) throw new ArgumentNullException("Specification is required");
+
             var evaluators = evaluateCriteriaOnly ? this.evaluators.Where(x => x.IsCriteriaEvaluator) : this.evaluators;
 
             foreach (var evaluator in evaluators)

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/RepositoryBaseOfT.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/RepositoryBaseOfT.cs
@@ -143,9 +143,6 @@ namespace Ardalis.Specification.EntityFrameworkCore
         /// <returns>The filtered projected entities as an <see cref="IQueryable{T}"/>.</returns>
         protected virtual IQueryable<TResult> ApplySpecification<TResult>(ISpecification<T, TResult> specification)
         {
-            if (specification is null) throw new ArgumentNullException("Specification is required");
-            if (specification.Selector is null) throw new SelectorNotFoundException();
-
             return specificationEvaluator.GetQuery(dbContext.Set<T>().AsQueryable(), specification);
         }
     }

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/RepositoryOfT_GetBySpec.cs
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/RepositoryOfT_GetBySpec.cs
@@ -98,7 +98,7 @@ namespace Ardalis.Specification.EntityFrameworkCore.IntegrationTests
 
             result.Should().NotBeNull();
             result?.Name.Should().Be(CompanySeed.VALID_COMPANY_NAME);
-            dbContext.Entry(result).State.Should().Be(Microsoft.EntityFrameworkCore.EntityState.Detached);
+            dbContext.Entry(result!).State.Should().Be(Microsoft.EntityFrameworkCore.EntityState.Detached);
         }
 
         [Fact]


### PR DESCRIPTION
Throw SelectorNotFound exception from the specification evaluator, and not from the repository. Users may have their own repository implementation, and ensuring the selector exists is crucial, so having the check in the evaluator is better.