### PR TITLE
Fix preprocessor directives in EF Core project to account for net6.0

### DIFF
--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
@@ -41,7 +41,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.18" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/AsNoTrackingWithIdentityResolutionEvaluator.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/AsNoTrackingWithIdentityResolutionEvaluator.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Ardalis.Specification.EntityFrameworkCore
 {
-#if NETSTANDARD2_1
+#if !NETSTANDARD2_0
     public class AsNoTrackingWithIdentityResolutionEvaluator : IEvaluator
     {
         private AsNoTrackingWithIdentityResolutionEvaluator() { }

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/AsSplitQueryEvaluator.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/AsSplitQueryEvaluator.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Ardalis.Specification.EntityFrameworkCore
 {
-#if NETSTANDARD2_1
+#if !NETSTANDARD2_0
     public class AsSplitQueryEvaluator : IEvaluator
     {
         private AsSplitQueryEvaluator() { }

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SpecificationEvaluator.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SpecificationEvaluator.cs
@@ -31,7 +31,7 @@ namespace Ardalis.Specification.EntityFrameworkCore
                 PaginationEvaluator.Instance,
                 AsNoTrackingEvaluator.Instance,
                 IgnoreQueryFiltersEvaluator.Instance,
-#if NETSTANDARD2_1
+#if !NETSTANDARD2_0
                 AsSplitQueryEvaluator.Instance,
                 AsNoTrackingWithIdentityResolutionEvaluator.Instance
 #endif


### PR DESCRIPTION
Some of the ORM features are not available in `EF Core 3`, so we've been using preprocessor directives. The condition was fine, but now that we added additional TFM `net6.0`, they're excluded from it as well.
```c#
	public SpecificationEvaluator(bool cacheEnabled = false)
	{
		this.evaluators.AddRange(new IEvaluator[]
		{
			WhereEvaluator.Instance,
			SearchEvaluator.Instance,
			cacheEnabled ? IncludeEvaluator.Cached : IncludeEvaluator.Default,
			OrderEvaluator.Instance,
			PaginationEvaluator.Instance,
			AsNoTrackingEvaluator.Instance,
			IgnoreQueryFiltersEvaluator.Instance,
#if NETSTANDARD2_1
			AsSplitQueryEvaluator.Instance,
			AsNoTrackingWithIdentityResolutionEvaluator.Instance
#endif
		});
	}
```
So, instead of `#if NETSTANDARD2_1`, we should use negation `#if !NETSTANDARD2_0`.