### PR TITLE
Fix nullability warnings.

### DIFF
--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
@@ -21,7 +21,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/CachedReadConcurrentDictionary.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/CachedReadConcurrentDictionary.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -12,7 +13,7 @@ namespace Ardalis.Specification.EntityFrameworkCore
     /// </summary>
     /// <typeparam name="TKey">The key type.</typeparam>
     /// <typeparam name="TValue">The value type.</typeparam>
-    internal class CachedReadConcurrentDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+    internal class CachedReadConcurrentDictionary<TKey, TValue> : IDictionary<TKey, TValue> where TKey : notnull
     {
         /// <summary>
         /// The number of cache misses which are tolerated before the cache is regenerated.
@@ -181,8 +182,14 @@ namespace Ardalis.Specification.EntityFrameworkCore
             return result;
         }
 
+#if NET6_0_OR_GREATER
+        /// <inheritdoc />
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value) => this.GetReadDictionary().TryGetValue(key, out value);
+#else
         /// <inheritdoc />
         public bool TryGetValue(TKey key, out TValue value) => this.GetReadDictionary().TryGetValue(key, out value);
+
+#endif
 
         /// <inheritdoc />
         public TValue this[TKey key]

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/RepositoryBaseOfT.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/RepositoryBaseOfT.cs
@@ -72,7 +72,7 @@ namespace Ardalis.Specification.EntityFrameworkCore
             return await ApplySpecification(specification).FirstOrDefaultAsync(cancellationToken);
         }
         /// <inheritdoc/>
-        public virtual async Task<TResult> GetBySpecAsync<TResult>(ISpecification<T, TResult> specification, CancellationToken cancellationToken = default)
+        public virtual async Task<TResult?> GetBySpecAsync<TResult>(ISpecification<T, TResult> specification, CancellationToken cancellationToken = default)
         {
             return await ApplySpecification(specification).FirstOrDefaultAsync(cancellationToken);
         }

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests.csproj
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <Nullable>enable</Nullable>
+	<LangVersion>9.0</LangVersion>
+	<Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Specification/src/Ardalis.Specification/Ardalis.Specification.csproj
+++ b/Specification/src/Ardalis.Specification/Ardalis.Specification.csproj
@@ -33,7 +33,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   

--- a/Specification/src/Ardalis.Specification/IReadRepositoryBase.cs
+++ b/Specification/src/Ardalis.Specification/IReadRepositoryBase.cs
@@ -43,7 +43,7 @@ namespace Ardalis.Specification
         /// A task that represents the asynchronous operation.
         /// The task result contains the <typeparamref name="TResult" />.
         /// </returns>
-        Task<TResult> GetBySpecAsync<TResult>(ISpecification<T, TResult> specification, CancellationToken cancellationToken = default);
+        Task<TResult?> GetBySpecAsync<TResult>(ISpecification<T, TResult> specification, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Finds all entities of <typeparamref name="T" /> from the database.

--- a/Specification/tests/Ardalis.Specification.UnitTests/Ardalis.Specification.UnitTests.csproj
+++ b/Specification/tests/Ardalis.Specification.UnitTests/Ardalis.Specification.UnitTests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The PR includes:
- The language version is updated to 9.0 for the following packages:
   - Ardalis.Specification (TFM: netstandard2.0)
   - Ardalis.Specification.EntityFrameworkCore (TFM: netstandard2.0, netstandard2.1, net6.0) 
- Fixed nullability warnings.

Closes #215 