### PR TITLE
Updated base specifications as non-abstract classes.

### DIFF
--- a/Specification/src/Ardalis.Specification/Specification.cs
+++ b/Specification/src/Ardalis.Specification/Specification.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 namespace Ardalis.Specification
 {
   /// <inheritdoc cref="ISpecification{T, TResult}"/>
-  public abstract class Specification<T, TResult> : Specification<T>, ISpecification<T, TResult>
+  public class Specification<T, TResult> : Specification<T>, ISpecification<T, TResult>
   {
     protected new virtual ISpecificationBuilder<T, TResult> Query { get; }
 
@@ -33,7 +33,7 @@ namespace Ardalis.Specification
   }
 
   /// <inheritdoc cref="ISpecification{T}"/>
-  public abstract class Specification<T> : ISpecification<T>
+  public class Specification<T> : ISpecification<T>
   {
     protected IInMemorySpecificationEvaluator Evaluator { get; }
     protected ISpecificationValidator Validator { get; }


### PR DESCRIPTION
We had a few requests for this. Frankly, there is no reason for them to be abstract, we're not requiring any contract in them. So, now users can create empty specifications simply by using `new Specification<T>()`. I have seen some interesting generic designs by users, and this would be of help to them.