### PR TITLE
Fixed test name description

### DIFF
--- a/Specification.EntityFramework6/tests/Ardalis.Specification.EntityFramework6.IntegrationTests/RepositoryOfT_AnyAsync.cs
+++ b/Specification.EntityFramework6/tests/Ardalis.Specification.EntityFramework6.IntegrationTests/RepositoryOfT_AnyAsync.cs
@@ -28,7 +28,7 @@ namespace Ardalis.Specification.EntityFramework6.IntegrationTests
     }
 
     [Fact]
-    public async Task ReturnsTrue_GivenStoreByIdSpecWithInvalidStore()
+    public async Task ReturnsFalse_GivenStoreByIdSpecWithInvalidStore()
     {
       var result = await storeRepository.AnyAsync(new StoreByIdSpec(0));
 

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/RepositoryOfT_AnyAsync.cs
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/RepositoryOfT_AnyAsync.cs
@@ -42,7 +42,7 @@ namespace Ardalis.Specification.EntityFrameworkCore.IntegrationTests
     }
 
     [Fact]
-    public virtual async Task ReturnsTrue_GivenStoreByIdSpecWithInvalidStore()
+    public virtual async Task ReturnsFalse_GivenStoreByIdSpecWithInvalidStore()
     {
       var result = await storeRepository.AnyAsync(new StoreByIdSpec(0));
 


### PR DESCRIPTION
There were a misleading on the test name description, saying it should return true but in fact it was expected a false result.
Also, the files EOL were modified  from CRLF to LF.