### PR TITLE
Publish version 6.1.0

### DIFF
--- a/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Ardalis.Specification.EntityFramework6.csproj
+++ b/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Ardalis.Specification.EntityFramework6.csproj
@@ -14,9 +14,15 @@
     <Summary>EF6 plugin package to Ardalis.Specification containing EF6 evaluator and abstract repository.</Summary>
     <RepositoryUrl>https://github.com/ardalis/specification</RepositoryUrl>
     <PackageTags>spec;specification;repository;ddd;ef;ef6;entity framework</PackageTags>
-    <Version>6.0.1</Version>
+    <Version>6.1.0</Version>
     <PackageReleaseNotes>
-     See README.md
+        - Added `AddRangeAsync`. [PR 239](https://github.com/ardalis/Specification/pull/239)
+        - Added dictionary as arbitrary state for specifications. [PR 248](https://github.com/ardalis/Specification/pull/248)
+        - Added support for updating specifications. [PR 251](https://github.com/ardalis/Specification/pull/251)
+        - Updated base specifications as non-abstract classes. [PR 252](https://github.com/ardalis/Specification/pull/252)
+        - Update the infrastructure for single result specifications. [PR 272](https://github.com/ardalis/Specification/pull/272)
+        - Added `UpdateRangeAsync`. [PR 272](https://github.com/ardalis/Specification/pull/272)
+        - Add WithSpecification overload for specifications with Select. [PR 273](https://github.com/ardalis/Specification/pull/273)
     </PackageReleaseNotes>
     <AssemblyName>Ardalis.Specification.EntityFramework6</AssemblyName>
     <PackageIcon>icon.png</PackageIcon>

--- a/Specification.EntityFramework6/tests/Ardalis.Specification.EntityFramework6.IntegrationTests/Ardalis.Specification.EntityFramework6.IntegrationTests.csproj
+++ b/Specification.EntityFramework6/tests/Ardalis.Specification.EntityFramework6.IntegrationTests/Ardalis.Specification.EntityFramework6.IntegrationTests.csproj
@@ -15,20 +15,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="altcover" Version="8.2.833" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="altcover" Version="8.2.837" />
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MartinCostello.SqlLocalDb" Version="3.1.0" />
-    <PackageReference Include="ReportGenerator" Version="5.0.2" />
-    <PackageReference Include="FluentAssertions" Version="6.3.0" />
+    <PackageReference Include="MartinCostello.SqlLocalDb" Version="3.2.0" />
+    <PackageReference Include="ReportGenerator" Version="5.1.9" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
@@ -12,9 +12,15 @@
     <Summary>EF Core plugin package to Ardalis.Specification containing EF Core evaluator and abstract repository.</Summary>
     <RepositoryUrl>https://github.com/ardalis/specification</RepositoryUrl>
     <PackageTags>spec;specification;repository;ddd;ef;ef core;entity framework;entity framework core</PackageTags>
-    <Version>6.0.1</Version>
+    <Version>6.1.0</Version>
     <PackageReleaseNotes>
-      See README.md
+        - Added `AddRangeAsync`. [PR 239](https://github.com/ardalis/Specification/pull/239)
+        - Added dictionary as arbitrary state for specifications. [PR 248](https://github.com/ardalis/Specification/pull/248)
+        - Added support for updating specifications. [PR 251](https://github.com/ardalis/Specification/pull/251)
+        - Updated base specifications as non-abstract classes. [PR 252](https://github.com/ardalis/Specification/pull/252)
+        - Update the infrastructure for single result specifications. [PR 272](https://github.com/ardalis/Specification/pull/272)
+        - Added `UpdateRangeAsync`. [PR 272](https://github.com/ardalis/Specification/pull/272)
+        - Add WithSpecification overload for specifications with Select. [PR 273](https://github.com/ardalis/Specification/pull/273)
     </PackageReleaseNotes>
     <AssemblyName>Ardalis.Specification.EntityFrameworkCore</AssemblyName>
     <PackageIcon>icon.png</PackageIcon>

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
@@ -31,8 +31,8 @@
   </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-	    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
-	    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.1" />
+	    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
+	    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.6" />
     </ItemGroup>
 	
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests.csproj
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests.csproj
@@ -8,20 +8,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="altcover" Version="8.2.833" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="altcover" Version="8.2.837" />
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MartinCostello.SqlLocalDb" Version="3.1.0" />
-    <PackageReference Include="ReportGenerator" Version="5.0.2" />
-    <PackageReference Include="FluentAssertions" Version="6.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
+    <PackageReference Include="MartinCostello.SqlLocalDb" Version="3.2.0" />
+    <PackageReference Include="ReportGenerator" Version="5.1.9" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Specification/src/Ardalis.Specification/Ardalis.Specification.csproj
+++ b/Specification/src/Ardalis.Specification/Ardalis.Specification.csproj
@@ -12,9 +12,15 @@
     <Summary>A simple package with a base Specification class, for use in creating queries that work with Repository types.</Summary>
     <RepositoryUrl>https://github.com/ardalis/specification</RepositoryUrl>
     <PackageTags>spec;specification;repository;ddd</PackageTags>
-    <Version>6.0.1</Version>
+    <Version>6.1.0</Version>
     <PackageReleaseNotes>
-      Fix XML Document Filename
+        - Added `AddRangeAsync`. [PR 239](https://github.com/ardalis/Specification/pull/239)
+        - Added dictionary as arbitrary state for specifications. [PR 248](https://github.com/ardalis/Specification/pull/248)
+        - Added support for updating specifications. [PR 251](https://github.com/ardalis/Specification/pull/251)
+        - Updated base specifications as non-abstract classes. [PR 252](https://github.com/ardalis/Specification/pull/252)
+        - Update the infrastructure for single result specifications. [PR 272](https://github.com/ardalis/Specification/pull/272)
+        - Added `UpdateRangeAsync`. [PR 272](https://github.com/ardalis/Specification/pull/272)
+        - Add WithSpecification overload for specifications with Select. [PR 273](https://github.com/ardalis/Specification/pull/273)
     </PackageReleaseNotes>
     <AssemblyName>Ardalis.Specification</AssemblyName>
     <PackageIcon>icon.png</PackageIcon>

--- a/Specification/tests/Ardalis.Specification.UnitTests/Ardalis.Specification.UnitTests.csproj
+++ b/Specification/tests/Ardalis.Specification.UnitTests/Ardalis.Specification.UnitTests.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="ReportGenerator" Version="5.0.2" />
-    <PackageReference Include="FluentAssertions" Version="6.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="ReportGenerator" Version="5.1.9" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/sample/Ardalis.SampleApp.Core/Ardalis.SampleApp.Core.csproj
+++ b/sample/Ardalis.SampleApp.Core/Ardalis.SampleApp.Core.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="3.3.0" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/Ardalis.SampleApp.Infrastructure/Ardalis.SampleApp.Infrastructure.csproj
+++ b/sample/Ardalis.SampleApp.Infrastructure/Ardalis.SampleApp.Infrastructure.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/Ardalis.SampleApp.Web/Ardalis.SampleApp.Web.csproj
+++ b/sample/Ardalis.SampleApp.Web/Ardalis.SampleApp.Web.csproj
@@ -5,14 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="11.0.0" />
+    <PackageReference Include="AutoMapper" Version="11.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated Nuget dependencies and updated version to 6.1.0

Changes:
- Added `AddRangeAsync`. [PR 239](https://github.com/ardalis/Specification/pull/239)
- Added dictionary as arbitrary state for specifications. [PR 248](https://github.com/ardalis/Specification/pull/248)
- Added support for updating specifications. [PR 251](https://github.com/ardalis/Specification/pull/251)
- Updated base specifications as non-abstract classes. [PR 252](https://github.com/ardalis/Specification/pull/252)
- Update the infrastructure for single result specifications. [PR 272](https://github.com/ardalis/Specification/pull/272)
- Added `UpdateRangeAsync`. [PR 272](https://github.com/ardalis/Specification/pull/272)
- Add WithSpecification overload for specifications with Select. [PR 273](https://github.com/ardalis/Specification/pull/273)
