### PR TITLE
Add two methods for consuming repositories in scenarios where repositories could be longer lived (e.g. Blazor component Injections)

### DIFF
--- a/Ardalis.Specification.sln
+++ b/Ardalis.Specification.sln
@@ -44,6 +44,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Specification.EntityFramewo
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Specification.EntityFramework6", "Specification.EntityFramework6", "{327AEBD6-C8A6-4851-BA42-632F8014CFC5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ardalis.Specification.EntityFrameworkCore.UnitTests", "Specification.EntityFrameworkCore\tests\Ardalis.Specification.EntityFrameworkCore.UnitTests\Ardalis.Specification.EntityFrameworkCore.UnitTests.csproj", "{53E4FFB4-CAC0-482D-B714-FA657C3244C9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,6 +88,10 @@ Global
 		{4BEB4DC4-DE33-4DF1-8A2F-CE76C1D72A4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4BEB4DC4-DE33-4DF1-8A2F-CE76C1D72A4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4BEB4DC4-DE33-4DF1-8A2F-CE76C1D72A4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{53E4FFB4-CAC0-482D-B714-FA657C3244C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53E4FFB4-CAC0-482D-B714-FA657C3244C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53E4FFB4-CAC0-482D-B714-FA657C3244C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53E4FFB4-CAC0-482D-B714-FA657C3244C9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -100,6 +106,7 @@ Global
 		{5AFD1454-E625-451D-A615-CEB7BB09AA65} = {B19F2F64-4B22-48C2-B2F8-7672F84F758D}
 		{37EC09C7-702D-4539-B98D-F67B15E1E6CE} = {327AEBD6-C8A6-4851-BA42-632F8014CFC5}
 		{4BEB4DC4-DE33-4DF1-8A2F-CE76C1D72A4A} = {327AEBD6-C8A6-4851-BA42-632F8014CFC5}
+		{53E4FFB4-CAC0-482D-B714-FA657C3244C9} = {B19F2F64-4B22-48C2-B2F8-7672F84F758D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C153A625-42F7-49A7-B99A-6A78B4B866B2}

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <PackageId>Ardalis.Specification.EntityFrameworkCore</PackageId>
     <Title>Ardalis.Specification.EntityFrameworkCore</Title>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/ContextFactoryRepositoryBaseOfT.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/ContextFactoryRepositoryBaseOfT.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Ardalis.Specification.EntityFrameworkCore
+{
+  public abstract class ContextFactoryRepositoryBaseOfT<TEntity, TContext> : IRepositoryBase<TEntity> 
+    where TEntity : class
+    where TContext : DbContext
+  {
+    private IDbContextFactory<TContext> dbContextFactory;
+    private ISpecificationEvaluator specificationEvaluator;
+
+    public ContextFactoryRepositoryBaseOfT(IDbContextFactory<TContext> dbContextFactory)
+      : this(dbContextFactory, SpecificationEvaluator.Default)
+    {
+    }
+
+    public ContextFactoryRepositoryBaseOfT(IDbContextFactory<TContext> dbContextFactory,
+      ISpecificationEvaluator specificationEvaluator)
+    {
+      this.dbContextFactory = dbContextFactory;
+      this.specificationEvaluator = specificationEvaluator;
+    }
+
+    /// <inheritdoc/>
+    public async Task<TEntity?> GetByIdAsync<TId>(TId id, CancellationToken cancellationToken = default) where TId : notnull
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      return await dbContext.Set<TEntity>().FindAsync(new object[] { id }, cancellationToken: cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<TEntity?> GetBySpecAsync(ISpecification<TEntity> specification, CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      return await ApplySpecification(specification, dbContext).FirstOrDefaultAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<TResult?> GetBySpecAsync<TResult>(ISpecification<TEntity, TResult> specification, CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      return await ApplySpecification(specification, dbContext).FirstOrDefaultAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<TEntity?> FirstOrDefaultAsync(ISpecification<TEntity> specification, CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      return await ApplySpecification(specification, dbContext).FirstOrDefaultAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<TResult?> FirstOrDefaultAsync<TResult>(ISpecification<TEntity, TResult> specification, CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      return await ApplySpecification(specification, dbContext).FirstOrDefaultAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<TEntity?> SingleOrDefaultAsync(ISingleResultSpecification<TEntity> specification, CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      return await ApplySpecification(specification, dbContext).FirstOrDefaultAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<TResult?> SingleOrDefaultAsync<TResult>(ISingleResultSpecification<TEntity, TResult> specification,
+      CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      return await ApplySpecification(specification, dbContext).FirstOrDefaultAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<TEntity>> ListAsync(CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      return await dbContext.Set<TEntity>().ToListAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<TEntity>> ListAsync(ISpecification<TEntity> specification, CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      var queryResult = await ApplySpecification(specification, dbContext).ToListAsync(cancellationToken);
+
+      return specification.PostProcessingAction == null ? queryResult : specification.PostProcessingAction(queryResult).ToList();
+    }
+    
+    /// <inheritdoc/>
+    public async Task<List<TResult>> ListAsync<TResult>(ISpecification<TEntity, TResult> specification, CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      var queryResult = await ApplySpecification(specification, dbContext).ToListAsync(cancellationToken);
+
+      return specification.PostProcessingAction == null ? queryResult : specification.PostProcessingAction(queryResult).ToList();
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> CountAsync(ISpecification<TEntity> specification, CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      return await ApplySpecification(specification, dbContext, true).CountAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> CountAsync(CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      return await dbContext.Set<TEntity>().CountAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> AnyAsync(ISpecification<TEntity> specification, CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      return await ApplySpecification(specification, dbContext, true).AnyAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> AnyAsync(CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      return await dbContext.Set<TEntity>().AnyAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<TEntity> AddAsync(TEntity entity, CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      dbContext.Set<TEntity>().Add(entity);
+
+      await SaveChangesAsync(dbContext, cancellationToken);
+
+      return entity;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<TEntity>> AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      dbContext.Set<TEntity>().AddRange(entities);
+
+      await SaveChangesAsync(dbContext, cancellationToken);
+
+      return entities;
+    }
+
+    /// <inheritdoc/>
+    public async Task UpdateAsync(TEntity entity, CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      dbContext.Set<TEntity>().Update(entity);
+
+      await SaveChangesAsync(dbContext, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task UpdateRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      dbContext.Set<TEntity>().UpdateRange(entities);
+
+      await SaveChangesAsync(dbContext, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task DeleteAsync(TEntity entity, CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      dbContext.Set<TEntity>().Remove(entity);
+
+      await SaveChangesAsync(dbContext, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task DeleteRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+    {
+      await using var dbContext = this.dbContextFactory.CreateDbContext();
+      dbContext.Set<TEntity>().RemoveRange(entities);
+
+      await SaveChangesAsync(dbContext, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+      throw new InvalidOperationException();
+    }
+
+    public async Task<int> SaveChangesAsync(TContext dbContext, CancellationToken cancellationToken = default)
+    {
+      return await dbContext.SaveChangesAsync(cancellationToken);
+    }
+    
+    /// <summary>
+    /// Filters the entities  of <typeparamref name="TEntity"/>, to those that match the encapsulated query logic of the
+    /// <paramref name="specification"/>.
+    /// </summary>
+    /// <param name="specification">The encapsulated query logic.</param>
+    /// <returns>The filtered entities as an <see cref="IQueryable{T}"/>.</returns>
+    protected virtual IQueryable<TEntity> ApplySpecification(ISpecification<TEntity> specification, TContext dbContext, bool evaluateCriteriaOnly = false)
+    {
+      return specificationEvaluator.GetQuery(dbContext.Set<TEntity>().AsQueryable(), specification, evaluateCriteriaOnly);
+    }
+
+    /// <summary>
+    /// Filters all entities of <typeparamref name="TEntity" />, that matches the encapsulated query logic of the
+    /// <paramref name="specification"/>, from the database.
+    /// <para>
+    /// Projects each entity into a new form, being <typeparamref name="TResult" />.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="TResult">The type of the value returned by the projection.</typeparam>
+    /// <param name="specification">The encapsulated query logic.</param>
+    /// <returns>The filtered projected entities as an <see cref="IQueryable{T}"/>.</returns>
+    protected virtual IQueryable<TResult> ApplySpecification<TResult>(ISpecification<TEntity, TResult> specification, TContext dbContext)
+    {
+      return specificationEvaluator.GetQuery(dbContext.Set<TEntity>().AsQueryable(), specification);
+    }
+  }
+}

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/EFRepositoryFactory.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/EFRepositoryFactory.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+
+namespace Ardalis.Specification.EntityFrameworkCore
+{
+  /// <summary>
+  /// 
+  /// </summary>
+  /// <typeparam name="TRepository">The Interface of the repository created by this Factory</typeparam>
+  /// <typeparam name="TConcreteRepository">
+  /// The Concrete implementation of the repository interface to create
+  /// </typeparam>
+  /// <typeparam name="TContext">The DbContext derived class to support the concrete repository</typeparam>
+  public class EFRepositoryFactory<TRepository, TConcreteRepository, TContext> : IRepositoryFactory<TRepository>
+    where TConcreteRepository : TRepository
+    where TContext : DbContext
+  {
+    private IDbContextFactory<TContext> dbContextFactory;
+
+    /// <summary>
+    /// Initialises a new instance of the EFRepositoryFactory
+    /// </summary>
+    /// <param name="dbContextFactory">The IDbContextFactory to use to generate the TContext</param>
+    public EFRepositoryFactory(IDbContextFactory<TContext> dbContextFactory)
+    {
+      this.dbContextFactory = dbContextFactory;
+    }
+
+    /// <inheritdoc />
+    public TRepository CreateRepository()
+    {
+      var args = new object[] { dbContextFactory.CreateDbContext() };
+      return (TRepository)Activator.CreateInstance(typeof(TConcreteRepository), args);
+    }
+  }
+}

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/IRepositoryFactory.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/IRepositoryFactory.cs
@@ -1,0 +1,18 @@
+﻿namespace Ardalis.Specification.EntityFrameworkCore
+{
+  /// <summary>
+  /// Generates new instances of <typeparamref name="TRepository"/> to encapsulate the 'Unit of Work' pattern
+  /// in scenarios where injected types may be long-lived (e.g. Blazor)
+  /// </summary>
+  /// <typeparam name="TRepository">
+  /// The Interface of the Repository to be generated.
+  /// </typeparam>
+  public interface IRepositoryFactory<TRepository>
+  {
+    /// <summary>
+    /// Generates a new repository instance
+    /// </summary>
+    /// <returns>The generated repository instance</returns>
+    public TRepository CreateRepository();
+  }
+}

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/ContextFactoryRepositoryBaseOfTTests.cs
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/ContextFactoryRepositoryBaseOfTTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Ardalis.Specification.EntityFrameworkCore.IntegrationTests.Fixture;
+using Ardalis.Specification.UnitTests.Fixture.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Ardalis.Specification.EntityFrameworkCore.IntegrationTests
+{
+  public class ContextFactoryRepositoryBaseOfTTests : IClassFixture<SharedDatabaseFixture>
+  {
+    protected TestDbContext dbContext;
+    protected IServiceProvider serviceProvider;
+    protected ContextFactoryRepository<Company, TestDbContext> repository;
+
+    public ContextFactoryRepositoryBaseOfTTests(SharedDatabaseFixture fixture)
+    {
+      dbContext = fixture.CreateContext();
+
+      serviceProvider = new ServiceCollection()
+        .AddDbContextFactory<TestDbContext>((builder => builder.UseSqlServer(fixture.Connection)),
+          ServiceLifetime.Transient).BuildServiceProvider();
+
+      var contextFactory = serviceProvider.GetService<IDbContextFactory<TestDbContext>>();
+      repository = new ContextFactoryRepository<Company, TestDbContext>(contextFactory);
+    }
+
+    [Fact]
+    public async Task Saves_new_entity()
+    {
+      var country = await dbContext.Countries.FirstOrDefaultAsync();
+
+      var company = new Company();
+      company.Name = "Test save new company name";
+      company.CountryId = country.Id;
+
+      await repository.AddAsync(company);
+      Assert.NotEqual(0, company.Id);
+    }
+
+    [Fact]
+    public async Task Updates_existing_entity()
+    {
+      var contextFactory = serviceProvider.GetService<IDbContextFactory<TestDbContext>>();
+      var companyRetrievalRepository = new ContextFactoryRepository<Company, TestDbContext>(contextFactory);
+      var companySaveRepository = new ContextFactoryRepository<Company, TestDbContext>(contextFactory);
+
+      var country = await dbContext.Countries.FirstOrDefaultAsync();
+
+      var company = new Company { Name = "Test update existing company name", CountryId = country.Id };
+      await repository.AddAsync(company);
+
+      var existingCompany = await companyRetrievalRepository.GetByIdAsync(company.Id);
+      existingCompany.Name = "Updated company name";
+      await companySaveRepository.UpdateAsync(existingCompany);
+
+      var validationCompany = await dbContext.Companies.FirstOrDefaultAsync(x => x.Id == company.Id);
+      Assert.Equal(validationCompany.Name, existingCompany.Name);
+    }
+
+    [Fact]
+    public async Task Updates_graph()
+    {
+      var contextFactory = serviceProvider.GetService<IDbContextFactory<TestDbContext>>();
+      var companyRetrievalRepository = new ContextFactoryRepository<Company, TestDbContext>(contextFactory);
+      var companySaveRepository = new ContextFactoryRepository<Company, TestDbContext>(contextFactory);
+
+      var country = await dbContext.Countries.FirstOrDefaultAsync();
+
+      var company = new Company { Name = "Test update graph", CountryId = country.Id };
+      var store = new Store { Name = "Store Number 1" };
+      company.Stores.Add(store);
+
+      await repository.AddAsync(company);
+
+      var spec = new GetCompanyWithStoresSpec(company.Id);
+      var existingCompany = await companyRetrievalRepository.FirstOrDefaultAsync(spec);
+      existingCompany.Name = "Updated company name";
+      var existingStore = existingCompany.Stores.FirstOrDefault();
+      existingStore.Name = "Updated Store Name";
+
+      await companySaveRepository.UpdateAsync(existingCompany);
+
+      var validationCompany = await dbContext.Companies.FirstOrDefaultAsync(x => x.Id == company.Id);
+      Assert.Equal(validationCompany.Name, existingCompany.Name);
+
+      var validationStore = await dbContext.Stores.FirstOrDefaultAsync(x => x.CompanyId == company.Id);
+      Assert.Equal(validationStore.Name, existingStore.Name);
+    }
+  }
+}

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/EFRepositoryFactoryTests.cs
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/EFRepositoryFactoryTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Ardalis.Specification.EntityFrameworkCore.IntegrationTests.Fixture;
+using Ardalis.Specification.UnitTests.Fixture.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Ardalis.Specification.EntityFrameworkCore.IntegrationTests
+{
+  public class EFRepositoryFactoryTests : IClassFixture<SharedDatabaseFixture>
+  {
+    protected TestDbContext dbContext;
+    protected IServiceProvider serviceProvider;
+    protected IRepositoryFactory<IRepositoryBase<Company>> repositoryFactory;
+    protected IDbContextFactory<TestDbContext> contextFactory;
+
+    public EFRepositoryFactoryTests(SharedDatabaseFixture fixture)
+    {
+      dbContext = fixture.CreateContext();
+      
+      serviceProvider = new ServiceCollection()
+        .AddDbContextFactory<TestDbContext>((builder => builder.UseSqlServer(fixture.Connection)),
+          ServiceLifetime.Transient).BuildServiceProvider();
+      
+      contextFactory = serviceProvider.GetService<IDbContextFactory<TestDbContext>>();
+      repositoryFactory =
+        new EFRepositoryFactory<IRepositoryBase<Company>, Repository<Company>, TestDbContext>(contextFactory);
+    }
+    
+    [Fact]
+    public async Task Saves_new_entity()
+    {
+      var repository = repositoryFactory.CreateRepository();
+      var country = await dbContext.Countries.FirstOrDefaultAsync();
+
+      var company = new Company();
+      company.Name = "Test save new company name";
+      company.CountryId = country.Id;
+
+      await repository.AddAsync(company);
+      Assert.NotEqual(0, company.Id);
+    }
+
+    [Fact]
+    public async Task Updates_existing_entity()
+    {
+      var repository = repositoryFactory.CreateRepository();
+      var country = await dbContext.Countries.FirstOrDefaultAsync();
+
+      var company = new Company { Name = "Test update existing company name", CountryId = country.Id };
+      await repository.AddAsync(company);
+
+      var existingCompany = await repository.GetByIdAsync(company.Id);
+      existingCompany.Name = "Updated company name";
+      await repository.UpdateAsync(existingCompany);
+
+      var validationCompany = await dbContext.Companies.FirstOrDefaultAsync(x => x.Id == company.Id);
+      Assert.Equal(validationCompany.Name, existingCompany.Name);
+    }
+
+    [Fact]
+    public async Task Updates_graph()
+    {
+      var repository = repositoryFactory.CreateRepository();
+      var country = await dbContext.Countries.FirstOrDefaultAsync();
+
+      var company = new Company { Name = "Test update graph", CountryId = country.Id };
+      var store = new Store { Name = "Store Number 1" };
+      company.Stores.Add(store);
+
+      await repository.AddAsync(company);
+
+      var spec = new GetCompanyWithStoresSpec(company.Id);
+      var existingCompany = await repository.FirstOrDefaultAsync(spec);
+      existingCompany.Name = "Updated company name";
+      var existingStore = existingCompany.Stores.FirstOrDefault();
+      existingStore.Name = "Updated Store Name";
+
+      await repository.UpdateAsync(existingCompany);
+
+      var validationCompany = await dbContext.Companies.FirstOrDefaultAsync(x => x.Id == company.Id);
+      Assert.Equal(validationCompany.Name, existingCompany.Name);
+
+      var validationStore = await dbContext.Stores.FirstOrDefaultAsync(x => x.CompanyId == company.Id);
+      Assert.Equal(validationStore.Name, existingStore.Name);
+    }
+  }
+}

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Fixture/ContextFactoryRepositoryOfT.cs
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Fixture/ContextFactoryRepositoryOfT.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Ardalis.Specification.EntityFrameworkCore.IntegrationTests.Fixture
+{
+  public class ContextFactoryRepository<T, TContext> : ContextFactoryRepositoryBaseOfT<T, TContext>
+    where T : class where TContext : DbContext
+  {
+    public ContextFactoryRepository(IDbContextFactory<TContext> dbContextFactory) : base(dbContextFactory)
+    {
+    }
+
+    public ContextFactoryRepository(IDbContextFactory<TContext> dbContextFactory,
+      ISpecificationEvaluator specificationEvaluator) : base(dbContextFactory, specificationEvaluator)
+    {
+    }
+  }
+}

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Fixture/GetCompanyWithStoresSpec.cs
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Fixture/GetCompanyWithStoresSpec.cs
@@ -1,0 +1,12 @@
+﻿using Ardalis.Specification.UnitTests.Fixture.Entities;
+
+namespace Ardalis.Specification.EntityFrameworkCore.IntegrationTests.Fixture
+{
+  public class GetCompanyWithStoresSpec : Specification<Company>, ISingleResultSpecification<Company>
+  {
+    public GetCompanyWithStoresSpec(int companyId)
+    {
+      this.Query.Where(x => x.Id == companyId).Include(x => x.Stores);
+    }
+  }
+}

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Fixture/RepositoryOfT.cs
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Fixture/RepositoryOfT.cs
@@ -5,6 +5,10 @@
   {
     protected readonly TestDbContext dbContext;
 
+    public Repository(TestDbContext dbContext) : this(dbContext, SpecificationEvaluator.Default)
+    {
+    }
+
     public Repository(TestDbContext dbContext, ISpecificationEvaluator specificationEvaluator) : base(dbContext, specificationEvaluator)
     {
       this.dbContext = dbContext;

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.UnitTests/Ardalis.Specification.EntityFrameworkCore.UnitTests.csproj
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.UnitTests/Ardalis.Specification.EntityFrameworkCore.UnitTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="Moq" Version="4.18.2" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\sample\Ardalis.SampleApp.Infrastructure\Ardalis.SampleApp.Infrastructure.csproj" />
+      <ProjectReference Include="..\..\src\Ardalis.Specification.EntityFrameworkCore\Ardalis.Specification.EntityFrameworkCore.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.UnitTests/EFRepositoryFactoryTests.cs
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.UnitTests/EFRepositoryFactoryTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Ardalis.Specification.EntityFrameworkCore.UnitTests;
 
-public class UnitTest1
+public class EFRepositoryFactoryTests
 {
   [Fact]
   public void CorrectlyInstantiatesRepository()

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.UnitTests/EFRepositoryFactoryTests.cs
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.UnitTests/EFRepositoryFactoryTests.cs
@@ -1,0 +1,27 @@
+﻿using Ardalis.SampleApp.Core.Entities.CustomerAggregate;
+using Ardalis.SampleApp.Core.Interfaces;
+using Ardalis.SampleApp.Infrastructure.Data;
+using Ardalis.SampleApp.Infrastructure.DataAccess;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Ardalis.Specification.EntityFrameworkCore.UnitTests;
+
+public class UnitTest1
+{
+  [Fact]
+  public void CorrectlyInstantiatesRepository()
+  {
+    var mockContextFactory = new Mock<IDbContextFactory<SampleDbContext>>();
+    mockContextFactory.Setup(x => x.CreateDbContext())
+      .Returns(() => new SampleDbContext(new DbContextOptions<SampleDbContext>()));
+
+    var repositoryFactory =
+      new EFRepositoryFactory<IRepository<Customer>, MyRepository<Customer>, SampleDbContext>(mockContextFactory
+        .Object);
+
+    var repository = repositoryFactory.CreateRepository();
+    Assert.IsType<MyRepository<Customer>>(repository);
+  }
+}


### PR DESCRIPTION
Provides two solutions for #280 

- BREAKING CHANGE - requires support for netstandard2.0 to be dropped from Ardalis.Specification.EntityFrameworkCore.csproj in order to make use of IDbContextFactory
- Add IRepositoryFactory interface and EFRepositoryFactory concrete implementation to encapsulate the 'Unit of Work' principle at the repository level, consuming DbContextFactories from DI containers such as those added using the .AddDbContextFactory method, following blazor best practices for managing DbContext lifetimes
- Add ContextFactoryRepositoryBaseOfT.cs abstract implementation of IRepositoryBase<T> which again consumes DbContextFactories from DI containers such as those added using the .AddDbContextFactory method but creates a new instance of the DbContext for every method call in the repository. This breaks Entity Framework change tracking so Update and Delete methods will have to be overloaded in concrete implementations using the TrackGraph method on the context.