### PR TITLE
Fix `Just the Docs` link in docs home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,4 +38,4 @@ Read the [Getting Started section](getting-started/). You can also [review the s
 
 ## Docs theme notes
 
-This docs site is using the [Just the Docs theme](https://pmarsceill.github.io/just-the-docs/docs/navigation-structure/). Details on how to configure its metadata and navigation can be found [here](https://pmarsceill.github.io/just-the-docs/docs/navigation-structure/).
+This docs site is using the [Just the Docs theme](https://just-the-docs.github.io/just-the-docs/). Details on how to configure its metadata and navigation can be found [here](https://just-the-docs.github.io/just-the-docs/docs/navigation-structure/).


### PR DESCRIPTION
The `Just the Docs` project is now hosted somewhere else.

Change our links to it in the `Docs theme notes` section of our own docs.

Gotta start somewhere 😉