### PR TITLE
Implement SelectMany support

### DIFF
--- a/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Evaluators/SpecificationEvaluator.cs
+++ b/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Evaluators/SpecificationEvaluator.cs
@@ -33,11 +33,14 @@ namespace Ardalis.Specification.EntityFramework6
     public virtual IQueryable<TResult> GetQuery<T, TResult>(IQueryable<T> query, ISpecification<T, TResult> specification) where T : class
     {
       if (specification is null) throw new ArgumentNullException("Specification is required");
-      if (specification.Selector is null) throw new SelectorNotFoundException();
+      if (specification.Selector is null && specification.SelectManyExpression is null) throw new SelectorNotFoundException();
+      if (specification.Selector != null && specification.SelectManyExpression != null) throw new ConcurrentSelectorsException();
 
       query = GetQuery(query, (ISpecification<T>)specification);
 
-      return query.Select(specification.Selector);
+      return specification.Selector != null
+        ? query.Select(specification.Selector)
+        : query.SelectMany(specification.SelectManyExpression);
     }
 
     /// <inheritdoc/>

--- a/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Evaluators/SpecificationEvaluator.cs
+++ b/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Evaluators/SpecificationEvaluator.cs
@@ -33,14 +33,14 @@ namespace Ardalis.Specification.EntityFramework6
     public virtual IQueryable<TResult> GetQuery<T, TResult>(IQueryable<T> query, ISpecification<T, TResult> specification) where T : class
     {
       if (specification is null) throw new ArgumentNullException("Specification is required");
-      if (specification.Selector is null && specification.SelectManyExpression is null) throw new SelectorNotFoundException();
-      if (specification.Selector != null && specification.SelectManyExpression != null) throw new ConcurrentSelectorsException();
+      if (specification.Selector is null && specification.SelectorMany is null) throw new SelectorNotFoundException();
+      if (specification.Selector != null && specification.SelectorMany != null) throw new ConcurrentSelectorsException();
 
       query = GetQuery(query, (ISpecification<T>)specification);
 
       return specification.Selector != null
         ? query.Select(specification.Selector)
-        : query.SelectMany(specification.SelectManyExpression);
+        : query.SelectMany(specification.SelectorMany);
     }
 
     /// <inheritdoc/>

--- a/Specification.EntityFramework6/tests/Ardalis.Specification.EntityFramework6.IntegrationTests/RepositoryOfT_ListAsync.cs
+++ b/Specification.EntityFramework6/tests/Ardalis.Specification.EntityFramework6.IntegrationTests/RepositoryOfT_ListAsync.cs
@@ -170,5 +170,15 @@ namespace Ardalis.Specification.EntityFramework6.IntegrationTests
       result[0].Id.Should().Be(StoreSeed.VALID_Search_ID);
       result[0].City.Should().Contain(StoreSeed.VALID_Search_City_Key);
     }
+
+    [Fact]
+    public virtual async Task ReturnsAllProducts_GivenStoreSelectManyProductsSpec()
+    {
+      var result = await storeRepository.ListAsync(new StoreProductNamesSpec());
+
+      result.Should().NotBeNull();
+      result.Should().HaveCount(ProductSeed.TOTAL_PRODUCT_COUNT);
+      result.OrderBy(x => x).First().Should().Be(ProductSeed.VALID_PRODUCT_NAME);
+    }
   }
 }

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SpecificationEvaluator.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SpecificationEvaluator.cs
@@ -47,11 +47,14 @@ namespace Ardalis.Specification.EntityFrameworkCore
     public virtual IQueryable<TResult> GetQuery<T, TResult>(IQueryable<T> query, ISpecification<T, TResult> specification) where T : class
     {
       if (specification is null) throw new ArgumentNullException("Specification is required");
-      if (specification.Selector is null) throw new SelectorNotFoundException();
+      if (specification.Selector is null && specification.SelectManyExpression is null) throw new SelectorNotFoundException();
+      if (specification.Selector != null && specification.SelectManyExpression != null) throw new ConcurrentSelectorsException();
 
       query = GetQuery(query, (ISpecification<T>)specification);
 
-      return query.Select(specification.Selector);
+      return specification.Selector is not null
+        ? query.Select(specification.Selector)
+        : query.SelectMany(specification.SelectManyExpression!);
     }
 
     /// <inheritdoc/>

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SpecificationEvaluator.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SpecificationEvaluator.cs
@@ -47,14 +47,14 @@ namespace Ardalis.Specification.EntityFrameworkCore
     public virtual IQueryable<TResult> GetQuery<T, TResult>(IQueryable<T> query, ISpecification<T, TResult> specification) where T : class
     {
       if (specification is null) throw new ArgumentNullException("Specification is required");
-      if (specification.Selector is null && specification.SelectManyExpression is null) throw new SelectorNotFoundException();
-      if (specification.Selector != null && specification.SelectManyExpression != null) throw new ConcurrentSelectorsException();
+      if (specification.Selector is null && specification.SelectorMany is null) throw new SelectorNotFoundException();
+      if (specification.Selector != null && specification.SelectorMany != null) throw new ConcurrentSelectorsException();
 
       query = GetQuery(query, (ISpecification<T>)specification);
 
       return specification.Selector is not null
         ? query.Select(specification.Selector)
-        : query.SelectMany(specification.SelectManyExpression!);
+        : query.SelectMany(specification.SelectorMany!);
     }
 
     /// <inheritdoc/>

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/RepositoryOfT_ListAsync.cs
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/RepositoryOfT_ListAsync.cs
@@ -196,5 +196,15 @@ namespace Ardalis.Specification.EntityFrameworkCore.IntegrationTests
       result[0].Id.Should().Be(StoreSeed.VALID_Search_ID);
       result[0].City.Should().Contain(StoreSeed.VALID_Search_City_Key);
     }
+
+    [Fact]
+    public virtual async Task ReturnsAllProducts_GivenStoreSelectManyProductsSpec()
+    {
+      var result = await storeRepository.ListAsync(new StoreProductNamesSpec());
+
+      result.Should().NotBeNull();
+      result.Should().HaveCount(ProductSeed.TOTAL_PRODUCT_COUNT);
+      result.OrderBy(x => x).First().Should().Be(ProductSeed.VALID_PRODUCT_NAME);
+    }
   }
 }

--- a/Specification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
+++ b/Specification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
@@ -292,6 +292,19 @@ namespace Ardalis.Specification
     }
 
     /// <summary>
+    /// Specify a transform function to apply to the <typeparamref name="T"/> element 
+    /// to produce a flattened sequence of <typeparamref name="TResult"/> elements.
+    /// </summary>
+    public static ISpecificationBuilder<T, TResult> SelectMany<T, TResult>(
+        this ISpecificationBuilder<T, TResult> specificationBuilder,
+        Expression<Func<T, IEnumerable<TResult>>> selector)
+    {
+      specificationBuilder.Specification.SelectManyExpression = selector;
+
+      return specificationBuilder;
+    }
+
+    /// <summary>
     /// Specify a transform function to apply to the result of the query 
     /// and returns the same <typeparamref name="T"/> type
     /// </summary>

--- a/Specification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
+++ b/Specification/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
@@ -299,7 +299,7 @@ namespace Ardalis.Specification
         this ISpecificationBuilder<T, TResult> specificationBuilder,
         Expression<Func<T, IEnumerable<TResult>>> selector)
     {
-      specificationBuilder.Specification.SelectManyExpression = selector;
+      specificationBuilder.Specification.SelectorMany = selector;
 
       return specificationBuilder;
     }

--- a/Specification/src/Ardalis.Specification/Evaluators/InMemorySpecificationEvaluator.cs
+++ b/Specification/src/Ardalis.Specification/Evaluators/InMemorySpecificationEvaluator.cs
@@ -31,14 +31,14 @@ namespace Ardalis.Specification
 
     public virtual IEnumerable<TResult> Evaluate<T, TResult>(IEnumerable<T> source, ISpecification<T, TResult> specification)
     {
-      if (specification.Selector is null && specification.SelectManyExpression is null) throw new SelectorNotFoundException();
-      if (specification.Selector != null && specification.SelectManyExpression != null) throw new ConcurrentSelectorsException();
+      if (specification.Selector is null && specification.SelectorMany is null) throw new SelectorNotFoundException();
+      if (specification.Selector != null && specification.SelectorMany != null) throw new ConcurrentSelectorsException();
 
       var baseQuery = Evaluate(source, (ISpecification<T>)specification);
 
       var resultQuery = specification.Selector != null
         ? baseQuery.Select(specification.Selector.Compile())
-        : baseQuery.SelectMany(specification.SelectManyExpression!.Compile());
+        : baseQuery.SelectMany(specification.SelectorMany!.Compile());
 
       return specification.PostProcessingAction == null
           ? resultQuery

--- a/Specification/src/Ardalis.Specification/Evaluators/InMemorySpecificationEvaluator.cs
+++ b/Specification/src/Ardalis.Specification/Evaluators/InMemorySpecificationEvaluator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -30,11 +31,14 @@ namespace Ardalis.Specification
 
     public virtual IEnumerable<TResult> Evaluate<T, TResult>(IEnumerable<T> source, ISpecification<T, TResult> specification)
     {
-      _ = specification.Selector ?? throw new SelectorNotFoundException();
+      if (specification.Selector is null && specification.SelectManyExpression is null) throw new SelectorNotFoundException();
+      if (specification.Selector != null && specification.SelectManyExpression != null) throw new ConcurrentSelectorsException();
 
       var baseQuery = Evaluate(source, (ISpecification<T>)specification);
 
-      var resultQuery = baseQuery.Select(specification.Selector.Compile());
+      var resultQuery = specification.Selector != null
+        ? baseQuery.Select(specification.Selector.Compile())
+        : baseQuery.SelectMany(specification.SelectManyExpression!.Compile());
 
       return specification.PostProcessingAction == null
           ? resultQuery

--- a/Specification/src/Ardalis.Specification/Exceptions/ConcurrentSelectorsException.cs
+++ b/Specification/src/Ardalis.Specification/Exceptions/ConcurrentSelectorsException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Ardalis.Specification
+{
+  public class ConcurrentSelectorsException : Exception
+  {
+    private const string message = "Concurrent specification selector transforms defined. Ensure only one of the Select() or SelectMany() transforms is used in the same specification!";
+
+    public ConcurrentSelectorsException()
+        : base(message)
+    {
+    }
+
+    public ConcurrentSelectorsException(Exception innerException)
+        : base(message, innerException)
+    {
+    }
+  }
+}

--- a/Specification/src/Ardalis.Specification/Exceptions/SelectorNotFoundException.cs
+++ b/Specification/src/Ardalis.Specification/Exceptions/SelectorNotFoundException.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Ardalis.Specification
 {
   public class SelectorNotFoundException : Exception
   {
-    private const string message = "The specification must have Selector defined.";
+    private const string message = "The specification must have a selector transform defined. Ensure either Select() or SelectMany() is used in the specification!";
 
     public SelectorNotFoundException()
         : base(message)

--- a/Specification/src/Ardalis.Specification/ISpecification.cs
+++ b/Specification/src/Ardalis.Specification/ISpecification.cs
@@ -22,7 +22,7 @@ namespace Ardalis.Specification
     /// <summary>
     /// The SelectMany transform function to apply to the <typeparamref name="T"/> element.
     /// </summary>
-    Expression<Func<T, IEnumerable<TResult>>>? SelectManyExpression { get; }
+    Expression<Func<T, IEnumerable<TResult>>>? SelectorMany { get; }
 
     /// <summary>
     /// The transform function to apply to the result of the query encapsulated by the <see cref="ISpecification{T, TResult}"/>.

--- a/Specification/src/Ardalis.Specification/ISpecification.cs
+++ b/Specification/src/Ardalis.Specification/ISpecification.cs
@@ -15,9 +15,14 @@ namespace Ardalis.Specification
     ISpecificationBuilder<T, TResult> Query { get; }
 
     /// <summary>
-    /// The transform function to apply to the <typeparamref name="T"/> element.
+    /// The Select transform function to apply to the <typeparamref name="T"/> element.
     /// </summary>
     Expression<Func<T, TResult>>? Selector { get; }
+
+    /// <summary>
+    /// The SelectMany transform function to apply to the <typeparamref name="T"/> element.
+    /// </summary>
+    Expression<Func<T, IEnumerable<TResult>>>? SelectManyExpression { get; }
 
     /// <summary>
     /// The transform function to apply to the result of the query encapsulated by the <see cref="ISpecification{T, TResult}"/>.

--- a/Specification/src/Ardalis.Specification/Specification.cs
+++ b/Specification/src/Ardalis.Specification/Specification.cs
@@ -29,6 +29,9 @@ namespace Ardalis.Specification
     public Expression<Func<T, TResult>>? Selector { get; internal set; }
 
     /// <inheritdoc/>
+    public Expression<Func<T, IEnumerable<TResult>>>? SelectManyExpression { get; internal set; }
+
+    /// <inheritdoc/>
     public new Func<IEnumerable<TResult>, IEnumerable<TResult>>? PostProcessingAction { get; internal set; } = null;
   }
 

--- a/Specification/src/Ardalis.Specification/Specification.cs
+++ b/Specification/src/Ardalis.Specification/Specification.cs
@@ -29,7 +29,7 @@ namespace Ardalis.Specification
     public Expression<Func<T, TResult>>? Selector { get; internal set; }
 
     /// <inheritdoc/>
-    public Expression<Func<T, IEnumerable<TResult>>>? SelectManyExpression { get; internal set; }
+    public Expression<Func<T, IEnumerable<TResult>>>? SelectorMany { get; internal set; }
 
     /// <inheritdoc/>
     public new Func<IEnumerable<TResult>, IEnumerable<TResult>>? PostProcessingAction { get; internal set; } = null;

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_SelectMany.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_SelectMany.cs
@@ -11,15 +11,15 @@ namespace Ardalis.Specification.UnitTests
     {
       var spec = new StoreProductNamesEmptySpec();
 
-      spec.SelectManyExpression.Should().BeNull();
+      spec.SelectorMany.Should().BeNull();
     }
 
     [Fact]
-    public void SetsSelector_GivenSelectManyExpression()
+    public void SetsSelectorMany_GivenSelectManyExpression()
     {
       var spec = new StoreProductNamesSpec();
 
-      spec.SelectManyExpression.Should().NotBeNull();
+      spec.SelectorMany.Should().NotBeNull();
     }
   }
 }

--- a/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_SelectMany.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/BuilderTests/SpecificationBuilderExtensions_SelectMany.cs
@@ -1,0 +1,25 @@
+﻿using Ardalis.Specification.UnitTests.Fixture.Specs;
+using FluentAssertions;
+using Xunit;
+
+namespace Ardalis.Specification.UnitTests
+{
+  public class SpecificationBuilderExtensions_SelectMany
+  {
+    [Fact]
+    public void SetsNothing_GivenNoSelectManyExpression()
+    {
+      var spec = new StoreProductNamesEmptySpec();
+
+      spec.SelectManyExpression.Should().BeNull();
+    }
+
+    [Fact]
+    public void SetsSelector_GivenSelectManyExpression()
+    {
+      var spec = new StoreProductNamesSpec();
+
+      spec.SelectManyExpression.Should().NotBeNull();
+    }
+  }
+}

--- a/Specification/tests/Ardalis.Specification.UnitTests/ExceptionTests/ConcurrentSelectorsExceptionTests.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/ExceptionTests/ConcurrentSelectorsExceptionTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Ardalis.Specification.UnitTests
+{
+  public class ConcurrentSelectorsExceptionTests
+  {
+    private const string defaultMessage = "Concurrent specification selector transforms defined. Ensure only one of the Select() or SelectMany() transforms is used in the same specification!";
+
+    [Fact]
+    public void ThrowWithDefaultConstructor()
+    {
+      Action action = () => throw new ConcurrentSelectorsException();
+
+      action.Should().Throw<ConcurrentSelectorsException>().WithMessage(defaultMessage);
+    }
+
+    [Fact]
+    public void ThrowWithInnerException()
+    {
+      Exception inner = new Exception("test");
+      Action action = () => throw new ConcurrentSelectorsException(inner);
+
+      action.Should().Throw<ConcurrentSelectorsException>().WithMessage(defaultMessage).WithInnerException<Exception>().WithMessage("test");
+    }
+  }
+}

--- a/Specification/tests/Ardalis.Specification.UnitTests/ExceptionTests/SelectorNotFoundExceptionTests.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/ExceptionTests/SelectorNotFoundExceptionTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using FluentAssertions;
 using Xunit;
 
@@ -8,7 +6,7 @@ namespace Ardalis.Specification.UnitTests
 {
   public class SelectorNotFoundExceptionTests
   {
-    private const string defaultMessage = "The specification must have Selector defined.";
+    private const string defaultMessage = "The specification must have a selector transform defined. Ensure either Select() or SelectMany() is used in the specification!";
 
     [Fact]
     public void ThrowWithDefaultConstructor()

--- a/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Entities/Seeds/ProductSeed.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Entities/Seeds/ProductSeed.cs
@@ -1,16 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Ardalis.Specification.UnitTests.Fixture.Entities.Seeds
 {
   public class ProductSeed
   {
+    public const int TOTAL_PRODUCT_COUNT = 100;
+    public const string VALID_PRODUCT_NAME = "Product 1";
+
     public static List<Product> Get()
     {
       var products = new List<Product>();
 
-      for (int i = 1; i < 100; i = i + 2)
+      for (int i = 1; i < TOTAL_PRODUCT_COUNT; i = i + 2)
       {
         products.Add(new Product()
         {

--- a/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/StoreProductNamesEmptySpec.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/StoreProductNamesEmptySpec.cs
@@ -1,0 +1,12 @@
+﻿using Ardalis.Specification.UnitTests.Fixture.Entities;
+
+namespace Ardalis.Specification.UnitTests.Fixture.Specs
+{
+  public class StoreProductNamesEmptySpec : Specification<Store, string?>
+  {
+    public StoreProductNamesEmptySpec()
+    {
+
+    }
+  }
+}

--- a/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/StoreProductNamesSpec.cs
+++ b/Specification/tests/Ardalis.Specification.UnitTests/Fixture/Specs/StoreProductNamesSpec.cs
@@ -1,0 +1,13 @@
+﻿using System.Linq;
+using Ardalis.Specification.UnitTests.Fixture.Entities;
+
+namespace Ardalis.Specification.UnitTests.Fixture.Specs
+{
+  public class StoreProductNamesSpec : Specification<Store, string?>
+  {
+    public StoreProductNamesSpec()
+    {
+      Query.SelectMany(s => s.Products.Select(p => p.Name));
+    }
+  }
+}


### PR DESCRIPTION
For issue https://github.com/ardalis/Specification/issues/294

Usage:
```c#
public class StoreProductNamesSpec : Specification<Store, string?>
{
  public StoreProductNamesSpec()
  {
    Query.SelectMany(s => s.Products.Select(p => p.Name));
  }
}
```

Concurrent usage of Select and SelectMany is prevented via a runtime evaluator exception.

We may want to rename `ISpecification<T, TResult>.Selector` to `SelectExpression` to match the newly added `SelectManyExpression` to be consistent (I couldn't come up with a good name other than SelectManyExpression).

Let me know how it looks - happy to make additional changes.