### PR TITLE
Updated projects, drop support for old TFMs.

### DIFF
--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <PackageId>Ardalis.Specification.EntityFrameworkCore</PackageId>
     <Title>Ardalis.Specification.EntityFrameworkCore</Title>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -34,20 +34,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-	    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
-	    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.6" />
-    </ItemGroup>
-	
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.13" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.13" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.18" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.6" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageId>Ardalis.Specification.EntityFrameworkCore</PackageId>
     <Title>Ardalis.Specification.EntityFrameworkCore</Title>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/ContextFactoryRepositoryBaseOfT.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/ContextFactoryRepositoryBaseOfT.cs
@@ -130,6 +130,13 @@ namespace Ardalis.Specification.EntityFrameworkCore
     }
 
     /// <inheritdoc/>
+    public IAsyncEnumerable<TEntity> AsAsyncEnumerable(ISpecification<TEntity> specification)
+    {
+      using var dbContext = this.dbContextFactory.CreateDbContext();
+      return ApplySpecification(specification, dbContext).AsAsyncEnumerable();
+    }
+
+    /// <inheritdoc/>
     public async Task<TEntity> AddAsync(TEntity entity, CancellationToken cancellationToken = default)
     {
       await using var dbContext = this.dbContextFactory.CreateDbContext();

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/RepositoryBaseOfT.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/RepositoryBaseOfT.cs
@@ -176,7 +176,7 @@ namespace Ardalis.Specification.EntityFrameworkCore
     /// <inheritdoc/>
     public virtual IAsyncEnumerable<T> AsAsyncEnumerable(ISpecification<T> specification)
     {
-      return ApplySpecification(specification, true).AsAsyncEnumerable();
+      return ApplySpecification(specification).AsAsyncEnumerable();
     }
 
     /// <summary>

--- a/Specification/src/Ardalis.Specification/Ardalis.Specification.csproj
+++ b/Specification/src/Ardalis.Specification/Ardalis.Specification.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <PackageId>Ardalis.Specification</PackageId>
     <Title>Ardalis.Specification</Title>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -33,7 +33,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
   

--- a/Specification/src/Ardalis.Specification/IReadRepositoryBase.cs
+++ b/Specification/src/Ardalis.Specification/IReadRepositoryBase.cs
@@ -168,7 +168,7 @@ namespace Ardalis.Specification
     Task<bool> AnyAsync(CancellationToken cancellationToken = default);
 
 
-#if !NETSTANDARD2_0
+#if NET6_0_OR_GREATER
     /// <summary>
     /// Finds all entities of <typeparamref name="T" />, that matches the encapsulated query logic of the
     /// <paramref name="specification"/>, from the database.

--- a/sample/Ardalis.SampleApp.Core/Ardalis.SampleApp.Core.csproj
+++ b/sample/Ardalis.SampleApp.Core/Ardalis.SampleApp.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/Ardalis.SampleApp.Infrastructure/Data/CachedCustomerRepository.cs
+++ b/sample/Ardalis.SampleApp.Infrastructure/Data/CachedCustomerRepository.cs
@@ -30,6 +30,12 @@ public class CachedRepository<T> : IReadRepository<T> where T : class, IAggregat
   }
 
   /// <inheritdoc/>
+  public virtual IAsyncEnumerable<T> AsAsyncEnumerable(ISpecification<T> specification)
+  {
+    return _sourceRepository.AsAsyncEnumerable(specification);
+  }
+
+  /// <inheritdoc/>
   public Task<bool> AnyAsync(Specification.ISpecification<T> specification, CancellationToken cancellationToken = default)
   {
     // TODO: Add Caching


### PR DESCRIPTION
Moving forward we'll drop support for some old TFMs. The projects are updated as follows:
- `Ardalis.Specification` - multi-target, `net6.0` and `netstandard2.0` (required for EF6 plugin package).
- `Ardalis.Specification.EntityFrameworkCore` - `net6.0`
- `Ardalis.Specification.EntityFramework6` - `net472`

NOTE: These are just the minimum required versions. The same is true for the dependencies. For example, `EntityFrameworkCore` package depends on version `6.0.6`, but consumers are free to install the newer versions explicitly.