### PR TITLE
Add support for extending default evaluator list

### DIFF
--- a/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Evaluators/SpecificationEvaluator.cs
+++ b/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Evaluators/SpecificationEvaluator.cs
@@ -10,11 +10,11 @@ namespace Ardalis.Specification.EntityFramework6
     // Will use singleton for default configuration. Yet, it can be instantiated if necessary, with default or provided evaluators.
     public static SpecificationEvaluator Default { get; } = new SpecificationEvaluator();
 
-    private readonly List<IEvaluator> evaluators = new List<IEvaluator>();
+    protected List<IEvaluator> Evaluators { get; } = new List<IEvaluator>();
 
     public SpecificationEvaluator()
     {
-      this.evaluators.AddRange(new IEvaluator[]
+      this.Evaluators.AddRange(new IEvaluator[]
       {
                 WhereEvaluator.Instance,
                 SearchEvaluator.Instance,
@@ -26,7 +26,7 @@ namespace Ardalis.Specification.EntityFramework6
     }
     public SpecificationEvaluator(IEnumerable<IEvaluator> evaluators)
     {
-      this.evaluators.AddRange(evaluators);
+      this.Evaluators.AddRange(evaluators);
     }
 
     /// <inheritdoc/>
@@ -48,7 +48,7 @@ namespace Ardalis.Specification.EntityFramework6
     {
       if (specification is null) throw new ArgumentNullException("Specification is required");
 
-      var evaluators = evaluateCriteriaOnly ? this.evaluators.Where(x => x.IsCriteriaEvaluator) : this.evaluators;
+      var evaluators = evaluateCriteriaOnly ? this.Evaluators.Where(x => x.IsCriteriaEvaluator) : this.Evaluators;
 
       foreach (var evaluator in evaluators)
       {

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SpecificationEvaluator.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SpecificationEvaluator.cs
@@ -18,11 +18,11 @@ namespace Ardalis.Specification.EntityFrameworkCore
     /// </summary>
     public static SpecificationEvaluator Cached { get; } = new SpecificationEvaluator(true);
 
-    private readonly List<IEvaluator> evaluators = new List<IEvaluator>();
+    protected List<IEvaluator> Evaluators { get; } = new List<IEvaluator>();
 
     public SpecificationEvaluator(bool cacheEnabled = false)
     {
-      this.evaluators.AddRange(new IEvaluator[]
+      this.Evaluators.AddRange(new IEvaluator[]
       {
                 WhereEvaluator.Instance,
                 SearchEvaluator.Instance,
@@ -40,7 +40,7 @@ namespace Ardalis.Specification.EntityFrameworkCore
 
     public SpecificationEvaluator(IEnumerable<IEvaluator> evaluators)
     {
-      this.evaluators.AddRange(evaluators);
+      this.Evaluators.AddRange(evaluators);
     }
 
     /// <inheritdoc/>
@@ -62,7 +62,7 @@ namespace Ardalis.Specification.EntityFrameworkCore
     {
       if (specification is null) throw new ArgumentNullException("Specification is required");
 
-      var evaluators = evaluateCriteriaOnly ? this.evaluators.Where(x => x.IsCriteriaEvaluator) : this.evaluators;
+      var evaluators = evaluateCriteriaOnly ? this.Evaluators.Where(x => x.IsCriteriaEvaluator) : this.Evaluators;
 
       foreach (var evaluator in evaluators)
       {

--- a/Specification/src/Ardalis.Specification/Evaluators/InMemorySpecificationEvaluator.cs
+++ b/Specification/src/Ardalis.Specification/Evaluators/InMemorySpecificationEvaluator.cs
@@ -12,11 +12,11 @@ namespace Ardalis.Specification
     // Will use singleton for default configuration. Yet, it can be instantiated if necessary, with default or provided evaluators.
     public static InMemorySpecificationEvaluator Default { get; } = new InMemorySpecificationEvaluator();
 
-    private readonly List<IInMemoryEvaluator> evaluators = new List<IInMemoryEvaluator>();
+    protected List<IInMemoryEvaluator> Evaluators { get; } = new List<IInMemoryEvaluator>();
 
     public InMemorySpecificationEvaluator()
     {
-      this.evaluators.AddRange(new IInMemoryEvaluator[]
+      this.Evaluators.AddRange(new IInMemoryEvaluator[]
       {
                 WhereEvaluator.Instance,
                 SearchEvaluator.Instance,
@@ -26,7 +26,7 @@ namespace Ardalis.Specification
     }
     public InMemorySpecificationEvaluator(IEnumerable<IInMemoryEvaluator> evaluators)
     {
-      this.evaluators.AddRange(evaluators);
+      this.Evaluators.AddRange(evaluators);
     }
 
     public virtual IEnumerable<TResult> Evaluate<T, TResult>(IEnumerable<T> source, ISpecification<T, TResult> specification)
@@ -47,7 +47,7 @@ namespace Ardalis.Specification
 
     public virtual IEnumerable<T> Evaluate<T>(IEnumerable<T> source, ISpecification<T> specification)
     {
-      foreach (var evaluator in evaluators)
+      foreach (var evaluator in Evaluators)
       {
         source = evaluator.Evaluate(source, specification);
       }


### PR DESCRIPTION
closes #308 

The PR enables us to more easily extend the evaluators list. We have exposed the state as protected.

```csharp
public class MyPartialEvaluator : IEvaluator
{
  private MyPartialEvaluator () { }
  public static MyPartialEvaluator Instance { get; } = new MyPartialEvaluator();

  public bool IsCriteriaEvaluator { get; } = true;

  public IQueryable<T> GetQuery<T>(IQueryable<T> query, ISpecification<T> specification) where T : class
  {
    // Write your desired implementation

    return query;
  }
}

public class MySpecificationEvaluator : SpecificationEvaluator
{
  public static MySpecificationEvaluator Instance { get; } = new MySpecificationEvaluator();

  private MySpecificationEvaluator() : base()
  {
    Evaluators.Add(MyPartialEvaluator .Instance);
  }
}
```