### PR TITLE
Add net6.0 TFM for EntityFramework6 package.

### DIFF
--- a/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Ardalis.Specification.EntityFramework6.csproj
+++ b/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Ardalis.Specification.EntityFramework6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <LangVersion>11.0</LangVersion>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Ardalis.Specification.EntityFramework6.csproj
+++ b/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/Ardalis.Specification.EntityFramework6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
     <LangVersion>11.0</LangVersion>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/RepositoryBaseOfT.cs
+++ b/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/RepositoryBaseOfT.cs
@@ -176,6 +176,14 @@ public abstract class RepositoryBase<T> : IRepositoryBase<T> where T : class
         return await _dbContext.Set<T>().AnyAsync(cancellationToken);
     }
 
+#if NET6_0_OR_GREATER
+    /// <inheritdoc/>
+    public virtual IAsyncEnumerable<T> AsAsyncEnumerable(ISpecification<T> specification)
+    {
+        throw new NotImplementedException();
+    }
+#endif
+
     /// <summary>
     /// Filters the entities  of <typeparamref name="T"/>, to those that match the encapsulated query logic of the
     /// <paramref name="specification"/>.

--- a/Specification.EntityFramework6/tests/Ardalis.Specification.EntityFramework6.IntegrationTests/Ardalis.Specification.EntityFramework6.IntegrationTests.csproj
+++ b/Specification.EntityFramework6/tests/Ardalis.Specification.EntityFramework6.IntegrationTests/Ardalis.Specification.EntityFramework6.IntegrationTests.csproj
@@ -1,19 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net7.0</TargetFrameworks>
     <LangVersion>11.0</LangVersion>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UseWindowsForms>true</UseWindowsForms>
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
-  
-  <ItemGroup>
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Data.Entity" />
-    <Reference Include="System.IdentityModel" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
@@ -22,17 +14,15 @@
     <PackageReference Include="MartinCostello.SqlLocalDb" Version="3.2.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="ReportGenerator" Version="5.1.23" />
-    <PackageReference Include="altcover" Version="8.6.68" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.analyzers" Version="1.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/Specification.EntityFramework6/tests/Ardalis.Specification.EntityFramework6.IntegrationTests/Fixture/SharedDatabaseFixture.cs
+++ b/Specification.EntityFramework6/tests/Ardalis.Specification.EntityFramework6.IntegrationTests/Fixture/SharedDatabaseFixture.cs
@@ -7,12 +7,11 @@ namespace Ardalis.Specification.EntityFramework6.IntegrationTests.Fixture;
 
 public class SharedDatabaseFixture : IDisposable
 {
-    // (docker)
-    public const string _connectionStringDocker = "Data Source=databaseEF6;Initial Catalog=SpecificationEF6TestsDB;PersistSecurityInfo=True;User ID=sa;Password=P@ssW0rd!";
+    public const string _connectionStringDocker =
+        "Data Source=databaseEF;Initial Catalog=SpecificationEF6TestsDB;PersistSecurityInfo=True;User ID=sa;Password=P@ssW0rd!;ConnectRetryCount=0;";
 
-    // (localdb)
-    public const string _connectionStringLocalDb = "Server=(localdb)\\mssqllocaldb;Integrated Security=SSPI;Initial Catalog=SpecificationEF6TestsDB;ConnectRetryCount=0";
-
+    public const string _connectionStringLocalDb = 
+        "Data Source=(localdb)\\mssqllocaldb;Integrated Security=SSPI;Initial Catalog=SpecificationEF6TestsDB;ConnectRetryCount=0;";
 
     public SharedDatabaseFixture()
     {

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests.csproj
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="MartinCostello.SqlLocalDb" Version="3.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.5.0" />

--- a/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Fixture/SharedDatabaseFixture.cs
+++ b/Specification.EntityFrameworkCore/tests/Ardalis.Specification.EntityFrameworkCore.IntegrationTests/Fixture/SharedDatabaseFixture.cs
@@ -7,9 +7,11 @@ namespace Ardalis.Specification.EntityFrameworkCore.IntegrationTests.Fixture;
 
 public class SharedDatabaseFixture : IDisposable
 {
-    public const string _connectionStringDocker = "Data Source=databaseEFCore;Initial Catalog=SpecificationEFCoreTestsDB;PersistSecurityInfo=True;User ID=sa;Password=P@ssW0rd!;TrustServerCertificate=Yes";
-    public const string _connectionStringLocalDb = "Server=(localdb)\\mssqllocaldb;Integrated Security=SSPI;Initial Catalog=SpecificationEFTestsDB;ConnectRetryCount=0";
+    public const string _connectionStringDocker = 
+        "Data Source=databaseEF;Initial Catalog=SpecificationEFTestsDB;PersistSecurityInfo=True;User ID=sa;Password=P@ssW0rd!;ConnectRetryCount=0;TrustServerCertificate=Yes;";
 
+    public const string _connectionStringLocalDb = 
+        "Data Source=(localdb)\\mssqllocaldb;Integrated Security=SSPI;Initial Catalog=SpecificationEFTestsDB;ConnectRetryCount=0;TrustServerCertificate=Yes;";
 
     private static readonly object _lock = new();
     private static bool _databaseInitialized;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,13 @@ services:
       context: .
       dockerfile: Dockerfile
     environment:
-      WAIT_HOSTS: databaseEFCore:1433
+      WAIT_HOSTS: databaseEF:1433
     volumes:
         - ./TestResults:/var/temp
     depends_on:
-      - databaseEFCore
+      - databaseEF
 
-  databaseEFCore:
+  databaseEF:
     image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
         SA_PASSWORD: "P@ssW0rd!"


### PR DESCRIPTION
Closes #340 
Updated the `EntityFramework6` package to multi-target `net472` and `net6.0`. Apparently, there are folks that use EF6 from `.NET` projects.