### PR TITLE
Add script for SQL Local DB setup.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.0.x
+    - name: Install SQL Local DB
+      run: ./setup-sqllocaldb.ps1
+      shell: pwsh
     - name: Build
       run: dotnet build ci.slnf --configuration Release
     - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.0.x
+    - name: Install SQL Local DB
+      run: ./setup-sqllocaldb.ps1
+      shell: pwsh
     - name: Build
       run: dotnet build ci.slnf --configuration Release
     - name: Test

--- a/Ardalis.Specification.sln
+++ b/Ardalis.Specification.sln
@@ -18,7 +18,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docker", "Docker", "{A74A4C
 		Dockerfile = Dockerfile
 		run-tests-docker.bat = run-tests-docker.bat
 		run-tests-docker.sh = run-tests-docker.sh
-		run-tests.sh = run-tests.sh
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Items", "_Solution Items", "{C443291A-7311-455F-9AC6-995EB29DD6D2}"
@@ -26,6 +25,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Items", "_Solutio
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
 		README.md = README.md
+		run-tests.sh = run-tests.sh
+		setup-sqllocaldb.ps1 = setup-sqllocaldb.ps1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sample", "Sample", "{1FCFDF4F-D0E2-4E30-8ABC-FE6DC3628228}"
@@ -46,7 +47,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ardalis.Sample.App1", "samp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ardalis.Sample.App3", "sample\Ardalis.Sample.App3\Ardalis.Sample.App3.csproj", "{ECBFDD7F-E60F-48C4-8279-DD6B3B03D27A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ardalis.Sample.App2", "sample\Ardalis.Sample.App2\Ardalis.Sample.App2.csproj", "{BDEF2EFE-6690-4022-86EF-AF7626366AD0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ardalis.Sample.App2", "sample\Ardalis.Sample.App2\Ardalis.Sample.App2.csproj", "{BDEF2EFE-6690-4022-86EF-AF7626366AD0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Specification/src/Ardalis.Specification/ISpecification.cs
+++ b/Specification/src/Ardalis.Specification/ISpecification.cs
@@ -15,7 +15,7 @@ public interface ISpecification<T, TResult> : ISpecification<T>
     new ISpecificationBuilder<T, TResult> Query { get; }
 
     /// <summary>
-    /// The Select transform function to apply to the <typeparamref name="T"/> element. 
+    /// The Select transform function to apply to the <typeparamref name="T"/> element.
     /// </summary>
     Expression<Func<T, TResult>>? Selector { get; }
 

--- a/setup-sqllocaldb.ps1
+++ b/setup-sqllocaldb.ps1
@@ -1,0 +1,33 @@
+# Taken from psake https://github.com/psake/psake
+
+<#
+.SYNOPSIS
+  This is a helper function that runs a scriptblock and checks the PS variable $lastexitcode
+  to see if an error occcured. If an error is detected then an exception is thrown.
+  This function allows you to run command-line programs without having to
+  explicitly check the $lastexitcode variable.
+.EXAMPLE
+  exec { svn info $repository_trunk } "Error executing SVN. Please verify SVN command-line client is installed"
+#>
+function Exec
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=0,Mandatory=1)][scriptblock]$cmd,
+        [Parameter(Position=1,Mandatory=0)][string]$errorMessage = ($msgs.error_bad_command -f $cmd)
+    )
+    & $cmd
+    if ($lastexitcode -ne 0) {
+        throw ("Exec: " + $errorMessage)
+    }
+}
+
+Write-Host "Downloading"
+Import-Module BitsTransfer
+Start-BitsTransfer -Source https://download.microsoft.com/download/7/c/1/7c14e92e-bdcb-4f89-b7cf-93543e7112d1/SqlLocalDB.msi -Destination SqlLocalDB.msi
+Write-Host "Installing"
+Start-Process -FilePath "SqlLocalDB.msi" -Wait -ArgumentList "/qn", "/norestart", "/l*v SqlLocalDBInstall.log", "IACCEPTSQLLOCALDBLICENSETERMS=YES";
+<#
+Write-Host "Checking"
+sqlcmd -l 60 -S "(localdb)\MSSQLLocalDB" -Q "SELECT @@VERSION;"
+#>


### PR DESCRIPTION
The `Local DB` comes pre-installed for Windows hosts, but our tests are occasionally failing to establish a connection. Adding an explicit task might ensure the DB is up and ready before it continues with the next job. At least I think so :) Let's try it.