### PR TITLE
Add messages to obsolete specs for clarity

### DIFF
--- a/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/RepositoryBaseOfT.cs
+++ b/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/RepositoryBaseOfT.cs
@@ -102,14 +102,14 @@ public abstract class RepositoryBase<T> : IRepositoryBase<T> where T : class
     }
 
     /// <inheritdoc/>
-    [Obsolete("Use ListAsync to query against a class extending Specification<T> when returning a collection. Use SingleOrDefault to query for a single record against a class extending SingleResultSpecification<T>")]
+    [Obsolete("Use FirstOrDefaultAsync<T> or SingleOrDefaultAsync<T> instead. The SingleOrDefaultAsync<T> can be applied only to SingleResultSpecification<T> specifications.")]
     public virtual async Task<T> GetBySpecAsync(ISpecification<T> specification, CancellationToken cancellationToken = default)
     {
         return await ApplySpecification(specification).FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
-    [Obsolete("Use ListAsync to query against a class extending Specification<T> when returning a collection. Use SingleOrDefault to query for a single record against a class extending SingleResultSpecification<T>")]
+    [Obsolete("Use FirstOrDefaultAsync<T> or SingleOrDefaultAsync<T> instead. The SingleOrDefaultAsync<T> can be applied only to SingleResultSpecification<T> specifications.")]
     public virtual async Task<TResult> GetBySpecAsync<TResult>(ISpecification<T, TResult> specification, CancellationToken cancellationToken = default)
     {
         return await ApplySpecification(specification).FirstOrDefaultAsync(cancellationToken);

--- a/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/RepositoryBaseOfT.cs
+++ b/Specification.EntityFramework6/src/Ardalis.Specification.EntityFramework6/RepositoryBaseOfT.cs
@@ -102,14 +102,14 @@ public abstract class RepositoryBase<T> : IRepositoryBase<T> where T : class
     }
 
     /// <inheritdoc/>
-    [Obsolete]
+    [Obsolete("Use ListAsync to query against a class extending Specification<T> when returning a collection. Use SingleOrDefault to query for a single record against a class extending SingleResultSpecification<T>")]
     public virtual async Task<T> GetBySpecAsync(ISpecification<T> specification, CancellationToken cancellationToken = default)
     {
         return await ApplySpecification(specification).FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
-    [Obsolete]
+    [Obsolete("Use ListAsync to query against a class extending Specification<T> when returning a collection. Use SingleOrDefault to query for a single record against a class extending SingleResultSpecification<T>")]
     public virtual async Task<TResult> GetBySpecAsync<TResult>(ISpecification<T, TResult> specification, CancellationToken cancellationToken = default)
     {
         return await ApplySpecification(specification).FirstOrDefaultAsync(cancellationToken);

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/RepositoryBaseOfT.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/RepositoryBaseOfT.cs
@@ -94,14 +94,14 @@ public abstract class RepositoryBase<T> : IRepositoryBase<T> where T : class
     }
 
     /// <inheritdoc/>
-    [Obsolete("Use ListAsync to query against a class extending Specification<T> when returning a collection. Use SingleOrDefault to query for a single record against a class extending SingleResultSpecification<T>")]
+    [Obsolete("Use FirstOrDefaultAsync<T> or SingleOrDefaultAsync<T> instead. The SingleOrDefaultAsync<T> can be applied only to SingleResultSpecification<T> specifications.")]
     public virtual async Task<T?> GetBySpecAsync(ISpecification<T> specification, CancellationToken cancellationToken = default)
     {
         return await ApplySpecification(specification).FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
-    [Obsolete("Use ListAsync to query against a class extending Specification<T> when returning a collection. Use SingleOrDefault to query for a single record against a class extending SingleResultSpecification<T>")]
+    [Obsolete("Use FirstOrDefaultAsync<T> or SingleOrDefaultAsync<T> instead. The SingleOrDefaultAsync<T> can be applied only to SingleResultSpecification<T> specifications.")]
     public virtual async Task<TResult?> GetBySpecAsync<TResult>(ISpecification<T, TResult> specification, CancellationToken cancellationToken = default)
     {
         return await ApplySpecification(specification).FirstOrDefaultAsync(cancellationToken);

--- a/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/RepositoryBaseOfT.cs
+++ b/Specification.EntityFrameworkCore/src/Ardalis.Specification.EntityFrameworkCore/RepositoryBaseOfT.cs
@@ -94,14 +94,14 @@ public abstract class RepositoryBase<T> : IRepositoryBase<T> where T : class
     }
 
     /// <inheritdoc/>
-    [Obsolete]
+    [Obsolete("Use ListAsync to query against a class extending Specification<T> when returning a collection. Use SingleOrDefault to query for a single record against a class extending SingleResultSpecification<T>")]
     public virtual async Task<T?> GetBySpecAsync(ISpecification<T> specification, CancellationToken cancellationToken = default)
     {
         return await ApplySpecification(specification).FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
-    [Obsolete]
+    [Obsolete("Use ListAsync to query against a class extending Specification<T> when returning a collection. Use SingleOrDefault to query for a single record against a class extending SingleResultSpecification<T>")]
     public virtual async Task<TResult?> GetBySpecAsync<TResult>(ISpecification<T, TResult> specification, CancellationToken cancellationToken = default)
     {
         return await ApplySpecification(specification).FirstOrDefaultAsync(cancellationToken);

--- a/Specification/src/Ardalis.Specification/IReadRepositoryBase.cs
+++ b/Specification/src/Ardalis.Specification/IReadRepositoryBase.cs
@@ -34,7 +34,7 @@ public interface IReadRepositoryBase<T> where T : class
     /// A task that represents the asynchronous operation.
     /// The task result contains the <typeparamref name="T" />, or <see langword="null"/>.
     /// </returns>
-    [Obsolete]
+    [Obsolete("Use ListAsync to query against a class extending Specification<T> when returning a collection. Use SingleOrDefault to query for a single record against a class extending SingleResultSpecification<T>")]
     Task<T?> GetBySpecAsync(ISpecification<T> specification, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -46,7 +46,7 @@ public interface IReadRepositoryBase<T> where T : class
     /// A task that represents the asynchronous operation.
     /// The task result contains the <typeparamref name="TResult" />.
     /// </returns>
-    [Obsolete]
+    [Obsolete("Use ListAsync to query against a class extending Specification<T> when returning a collection. Use SingleOrDefault to query for a single record against a class extending SingleResultSpecification<T>")]
     Task<TResult?> GetBySpecAsync<TResult>(ISpecification<T, TResult> specification, CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/Specification/src/Ardalis.Specification/IReadRepositoryBase.cs
+++ b/Specification/src/Ardalis.Specification/IReadRepositoryBase.cs
@@ -34,7 +34,7 @@ public interface IReadRepositoryBase<T> where T : class
     /// A task that represents the asynchronous operation.
     /// The task result contains the <typeparamref name="T" />, or <see langword="null"/>.
     /// </returns>
-    [Obsolete("Use ListAsync to query against a class extending Specification<T> when returning a collection. Use SingleOrDefault to query for a single record against a class extending SingleResultSpecification<T>")]
+    [Obsolete("Use FirstOrDefaultAsync<T> or SingleOrDefaultAsync<T> instead. The SingleOrDefaultAsync<T> can be applied only to SingleResultSpecification<T> specifications.")]
     Task<T?> GetBySpecAsync(ISpecification<T> specification, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -46,7 +46,7 @@ public interface IReadRepositoryBase<T> where T : class
     /// A task that represents the asynchronous operation.
     /// The task result contains the <typeparamref name="TResult" />.
     /// </returns>
-    [Obsolete("Use ListAsync to query against a class extending Specification<T> when returning a collection. Use SingleOrDefault to query for a single record against a class extending SingleResultSpecification<T>")]
+    [Obsolete("Use FirstOrDefaultAsync<T> or SingleOrDefaultAsync<T> instead. The SingleOrDefaultAsync<T> can be applied only to SingleResultSpecification<T> specifications.")]
     Task<TResult?> GetBySpecAsync<TResult>(ISpecification<T, TResult> specification, CancellationToken cancellationToken = default);
 
     /// <summary>


### PR DESCRIPTION
Super simple contribution but hopefully a helpful one.

I noticed the obsolete warnings when working in our organization's server repo and it took 15 minutes of research and git blame to find the commit where these were marked obsolete, study the code and determine what I should have been doing instead.

I figured I'd contribute to the project to save the next guy some time. Ardalis is a major backbone of our project so I hope this contribution helps. 🙂 