### PR TITLE
Update GitHub workflows to use Linux hosts.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     
     steps:
     - name: Checkout
@@ -26,10 +26,7 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.x
-    - name: Install SQL Local DB
-      run: ./setup-sqllocaldb.ps1
-      shell: pwsh
     - name: Build
       run: dotnet build ci.slnf --configuration Release
     - name: Test
-      run: dotnet test ci.slnf --configuration Release --no-build --no-restore
+      run: dotnet test ci.slnf --configuration Release --no-build --no-restore --framework net9.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     
     steps:
     - name: Checkout
@@ -15,13 +15,10 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.x
-    - name: Install SQL Local DB
-      run: ./setup-sqllocaldb.ps1
-      shell: pwsh
     - name: Build
       run: dotnet build ci.slnf --configuration Release
     - name: Test
-      run: dotnet test ci.slnf --configuration Release --no-build --no-restore
+      run: dotnet test ci.slnf --configuration Release --no-build --no-restore --framework net9.0
     - name: Pack
       run: dotnet pack ci.slnf --configuration Release --no-build --no-restore --output .
     - name: Push to NuGet

--- a/coverage.sh
+++ b/coverage.sh
@@ -17,7 +17,7 @@ testtarget="ci.slnf"
 fi
 
 dotnet build $testtarget --configuration Release
-dotnet test $testtarget --configuration Release --no-build --no-restore --collect:"XPlat Code Coverage"
+dotnet test $testtarget --configuration Release --no-build --no-restore --framework net9.0 --collect:"XPlat Code Coverage"
 
 reportgenerator \
     -reports:tests/**/coverage.cobertura.xml \

--- a/src/Ardalis.Specification.EntityFramework6/Ardalis.Specification.EntityFramework6.csproj
+++ b/src/Ardalis.Specification.EntityFramework6/Ardalis.Specification.EntityFramework6.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net472;</TargetFrameworks>
-    <LangVersion>13.0</LangVersion>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     

--- a/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
+++ b/src/Ardalis.Specification.EntityFrameworkCore/Ardalis.Specification.EntityFrameworkCore.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-    <LangVersion>13.0</LangVersion>
     <Nullable>enable</Nullable>
     
     <AssemblyName>Ardalis.Specification.EntityFrameworkCore</AssemblyName>

--- a/src/Ardalis.Specification/Ardalis.Specification.csproj
+++ b/src/Ardalis.Specification/Ardalis.Specification.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;netstandard2.0</TargetFrameworks>
-    <LangVersion>13.0</LangVersion>
     <Nullable>enable</Nullable>
     
     <AssemblyName>Ardalis.Specification</AssemblyName>


### PR DESCRIPTION
We've been using Windows hosts and LocalDb database for the CI workflows. That's mainly because of the EF6 package and `net472` target.

But it's not stable, and we have random fails. The connection to localDb fails because it's not always up and ready. We can mitigate the issue by waiting for the database to be ready before running the tests.

Anyhow instead of all that, since the EF6 package targets `net9.0` too; then let's just use ubuntu hosts and run tests using only `net9.0` runtime. We're using TestContainers, so we won't need localDb, we'll utilize the mssql container for the tests.

It's a bit of a risk not to run the tests for `net472` target, but it's a rarely changing package. And also we may always run it locally.