### PR TITLE
Reduce the size of specifications and avoid unnecessary memory allocations

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
   </ItemGroup>
   
   <ItemGroup Label="Test projects dependencies">
+    <PackageVersion Include="ManagedObjectSize.ObjectPool" Version="0.0.7-gd53ba9da59" />
     <PackageVersion Include="MartinCostello.SqlLocalDb" Version="3.4.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2" />
     <PackageVersion Include="Respawn" Version="6.2.1" />

--- a/src/Ardalis.Specification/Builder/IncludableBuilderExtensions.cs
+++ b/src/Ardalis.Specification/Builder/IncludableBuilderExtensions.cs
@@ -16,9 +16,8 @@ public static class IncludableBuilderExtensions
     {
         if (condition && !previousBuilder.IsChainDiscarded)
         {
-            var info = new IncludeExpressionInfo(thenIncludeExpression, typeof(TEntity), typeof(TProperty), typeof(TPreviousProperty));
-
-            ((List<IncludeExpressionInfo>)previousBuilder.Specification.IncludeExpressions).Add(info);
+            var expr = new IncludeExpressionInfo(thenIncludeExpression, typeof(TEntity), typeof(TProperty), typeof(TPreviousProperty));
+            previousBuilder.Specification.Add(expr);
         }
 
         var includeBuilder = new IncludableSpecificationBuilder<TEntity, TProperty>(previousBuilder.Specification, !condition || previousBuilder.IsChainDiscarded);
@@ -40,9 +39,8 @@ public static class IncludableBuilderExtensions
     {
         if (condition && !previousBuilder.IsChainDiscarded)
         {
-            var info = new IncludeExpressionInfo(thenIncludeExpression, typeof(TEntity), typeof(TProperty), typeof(IEnumerable<TPreviousProperty>));
-
-            ((List<IncludeExpressionInfo>)previousBuilder.Specification.IncludeExpressions).Add(info);
+            var expr = new IncludeExpressionInfo(thenIncludeExpression, typeof(TEntity), typeof(TProperty), typeof(IEnumerable<TPreviousProperty>));
+            previousBuilder.Specification.Add(expr);
         }
 
         var includeBuilder = new IncludableSpecificationBuilder<TEntity, TProperty>(previousBuilder.Specification, !condition || previousBuilder.IsChainDiscarded);

--- a/src/Ardalis.Specification/Builder/OrderedBuilderExtensions.cs
+++ b/src/Ardalis.Specification/Builder/OrderedBuilderExtensions.cs
@@ -14,7 +14,8 @@ public static class OrderedBuilderExtensions
     {
         if (condition && !orderedBuilder.IsChainDiscarded)
         {
-            ((List<OrderExpressionInfo<T>>)orderedBuilder.Specification.OrderExpressions).Add(new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.ThenBy));
+            var expr = new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.ThenBy);
+            orderedBuilder.Specification.Add(expr);
         }
         else
         {
@@ -36,7 +37,8 @@ public static class OrderedBuilderExtensions
     {
         if (condition && !orderedBuilder.IsChainDiscarded)
         {
-            ((List<OrderExpressionInfo<T>>)orderedBuilder.Specification.OrderExpressions).Add(new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.ThenByDescending));
+            var expr = new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.ThenByDescending);
+            orderedBuilder.Specification.Add(expr);
         }
         else
         {

--- a/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
+++ b/src/Ardalis.Specification/Builder/SpecificationBuilderExtensions.cs
@@ -27,7 +27,8 @@ public static class SpecificationBuilderExtensions
     {
         if (condition)
         {
-            ((List<WhereExpressionInfo<T>>)specificationBuilder.Specification.WhereExpressions).Add(new WhereExpressionInfo<T>(criteria));
+            var expr = new WhereExpressionInfo<T>(criteria);
+            specificationBuilder.Specification.Add(expr);
         }
 
         return specificationBuilder;
@@ -58,7 +59,8 @@ public static class SpecificationBuilderExtensions
     {
         if (condition)
         {
-            ((List<OrderExpressionInfo<T>>)specificationBuilder.Specification.OrderExpressions).Add(new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.OrderBy));
+            var expr = new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.OrderBy);
+            specificationBuilder.Specification.Add(expr);
         }
 
         var orderedSpecificationBuilder = new OrderedSpecificationBuilder<T>(specificationBuilder.Specification, !condition);
@@ -91,7 +93,8 @@ public static class SpecificationBuilderExtensions
     {
         if (condition)
         {
-            ((List<OrderExpressionInfo<T>>)specificationBuilder.Specification.OrderExpressions).Add(new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.OrderByDescending));
+            var expr = new OrderExpressionInfo<T>(orderExpression, OrderTypeEnum.OrderByDescending);
+            specificationBuilder.Specification.Add(expr);
         }
 
         var orderedSpecificationBuilder = new OrderedSpecificationBuilder<T>(specificationBuilder.Specification, !condition);
@@ -130,9 +133,8 @@ public static class SpecificationBuilderExtensions
     {
         if (condition)
         {
-            var info = new IncludeExpressionInfo(includeExpression, typeof(T), typeof(TProperty));
-
-            ((List<IncludeExpressionInfo>)specificationBuilder.Specification.IncludeExpressions).Add(info);
+            var expr = new IncludeExpressionInfo(includeExpression, typeof(T), typeof(TProperty));
+            specificationBuilder.Specification.Add(expr);
         }
 
         var includeBuilder = new IncludableSpecificationBuilder<T, TProperty>(specificationBuilder.Specification, !condition);
@@ -165,7 +167,7 @@ public static class SpecificationBuilderExtensions
     {
         if (condition)
         {
-            ((List<string>)specificationBuilder.Specification.IncludeStrings).Add(includeString);
+            specificationBuilder.Specification.Add(includeString);
         }
 
         return specificationBuilder;
@@ -204,7 +206,8 @@ public static class SpecificationBuilderExtensions
     {
         if (condition)
         {
-            ((List<SearchExpressionInfo<T>>)specificationBuilder.Specification.SearchCriterias).Add(new SearchExpressionInfo<T>(selector, searchTerm, searchGroup));
+            var expr = new SearchExpressionInfo<T>(selector, searchTerm, searchGroup);
+            specificationBuilder.Specification.Add(expr);
         }
 
         return specificationBuilder;
@@ -233,7 +236,7 @@ public static class SpecificationBuilderExtensions
     {
         if (condition)
         {
-            if (specificationBuilder.Specification.Take != null) throw new DuplicateTakeException();
+            if (specificationBuilder.Specification.Take != -1) throw new DuplicateTakeException();
 
             specificationBuilder.Specification.Take = take;
         }
@@ -266,7 +269,7 @@ public static class SpecificationBuilderExtensions
     {
         if (condition)
         {
-            if (specificationBuilder.Specification.Skip != null) throw new DuplicateSkipException();
+            if (specificationBuilder.Specification.Skip != -1) throw new DuplicateSkipException();
 
             specificationBuilder.Specification.Skip = skip;
         }
@@ -357,8 +360,6 @@ public static class SpecificationBuilderExtensions
             }
 
             specificationBuilder.Specification.CacheKey = $"{specificationName}-{string.Join("-", args)}";
-
-            specificationBuilder.Specification.CacheEnabled = true;
         }
 
         var cacheBuilder = new CacheSpecificationBuilder<T>(specificationBuilder.Specification, !condition);

--- a/src/Ardalis.Specification/Evaluators/PaginationEvaluator.cs
+++ b/src/Ardalis.Specification/Evaluators/PaginationEvaluator.cs
@@ -10,14 +10,14 @@ public class PaginationEvaluator : IEvaluator, IInMemoryEvaluator
     public IQueryable<T> GetQuery<T>(IQueryable<T> query, ISpecification<T> specification) where T : class
     {
         // If skip is 0, avoid adding to the IQueryable. It will generate more optimized SQL that way.
-        if (specification.Skip != null && specification.Skip != 0)
+        if (specification.Skip > 0)
         {
-            query = query.Skip(specification.Skip.Value);
+            query = query.Skip(specification.Skip);
         }
 
-        if (specification.Take != null)
+        if (specification.Take >= 0)
         {
-            query = query.Take(specification.Take.Value);
+            query = query.Take(specification.Take);
         }
 
         return query;
@@ -25,14 +25,14 @@ public class PaginationEvaluator : IEvaluator, IInMemoryEvaluator
 
     public IEnumerable<T> Evaluate<T>(IEnumerable<T> query, ISpecification<T> specification)
     {
-        if (specification.Skip != null && specification.Skip != 0)
+        if (specification.Skip > 0)
         {
-            query = query.Skip(specification.Skip.Value);
+            query = query.Skip(specification.Skip);
         }
 
-        if (specification.Take != null)
+        if (specification.Take >= 0)
         {
-            query = query.Take(specification.Take.Value);
+            query = query.Take(specification.Take);
         }
 
         return query;

--- a/src/Ardalis.Specification/ISpecification.cs
+++ b/src/Ardalis.Specification/ISpecification.cs
@@ -39,7 +39,7 @@ public interface ISpecification<T>
     /// <summary>
     /// Arbitrary state to be accessed from builders and evaluators.
     /// </summary>
-    IDictionary<string, object> Items { get; set; }
+    Dictionary<string, object> Items { get; }
 
     /// <summary>
     /// The collection of filters.
@@ -71,12 +71,12 @@ public interface ISpecification<T>
     /// <summary>
     /// The number of elements to return.
     /// </summary>
-    int? Take { get; }
+    int Take { get; }
 
     /// <summary>
     /// The number of elements to skip before returning the remaining elements.
     /// </summary>
-    int? Skip { get; }
+    int Skip { get; }
 
     /// <summary>
     /// The transform function to apply to the result of the query encapsulated by the <see cref="ISpecification{T}"/>.

--- a/src/Ardalis.Specification/Specification.cs
+++ b/src/Ardalis.Specification/Specification.cs
@@ -3,23 +3,7 @@
 /// <inheritdoc cref="ISpecification{T, TResult}"/>
 public class Specification<T, TResult> : Specification<T>, ISpecification<T, TResult>
 {
-    public new virtual ISpecificationBuilder<T, TResult> Query { get; }
-
-    public Specification()
-        : this(InMemorySpecificationEvaluator.Default)
-    {
-    }
-
-    public Specification(IInMemorySpecificationEvaluator inMemorySpecificationEvaluator)
-        : base(inMemorySpecificationEvaluator)
-    {
-        Query = new SpecificationBuilder<T, TResult>(this);
-    }
-
-    public new virtual IEnumerable<TResult> Evaluate(IEnumerable<T> entities)
-    {
-        return Evaluator.Evaluate(entities, this);
-    }
+    public new ISpecificationBuilder<T, TResult> Query => new SpecificationBuilder<T, TResult>(this);
 
     /// <inheritdoc/>
     public Expression<Func<T, TResult>>? Selector { get; internal set; }
@@ -29,93 +13,102 @@ public class Specification<T, TResult> : Specification<T>, ISpecification<T, TRe
 
     /// <inheritdoc/>
     public new Func<IEnumerable<TResult>, IEnumerable<TResult>>? PostProcessingAction { get; internal set; } = null;
+
+    public new virtual IEnumerable<TResult> Evaluate(IEnumerable<T> entities)
+    {
+        var evaluator = Evaluator;
+        return evaluator.Evaluate(entities, this);
+    }
 }
 
 /// <inheritdoc cref="ISpecification{T}"/>
 public class Specification<T> : ISpecification<T>
 {
-    protected IInMemorySpecificationEvaluator Evaluator { get; }
-    protected ISpecificationValidator Validator { get; }
-    public virtual ISpecificationBuilder<T> Query { get; }
+    // The state is null initially, but we're spending 8 bytes per reference (on x64).
+    // This will be reconsidered for version 10 where we may store the whole state as a single array of structs.
+    private List<WhereExpressionInfo<T>>? _whereExpressions;
+    private List<SearchExpressionInfo<T>>? _searchExpressions;
+    private List<OrderExpressionInfo<T>>? _orderExpressions;
+    private List<IncludeExpressionInfo>? _includeExpressions;
+    private List<string>? _includeStrings;
+    private Dictionary<string, object>? _items;
 
-    public Specification()
-        : this(InMemorySpecificationEvaluator.Default, SpecificationValidator.Default)
-    {
-    }
-
-    public Specification(IInMemorySpecificationEvaluator inMemorySpecificationEvaluator)
-        : this(inMemorySpecificationEvaluator, SpecificationValidator.Default)
-    {
-    }
-
-    public Specification(ISpecificationValidator specificationValidator)
-        : this(InMemorySpecificationEvaluator.Default, specificationValidator)
-    {
-    }
-
-    public Specification(IInMemorySpecificationEvaluator inMemorySpecificationEvaluator, ISpecificationValidator specificationValidator)
-    {
-        Evaluator = inMemorySpecificationEvaluator;
-        Validator = specificationValidator;
-        Query = new SpecificationBuilder<T>(this);
-    }
+    public ISpecificationBuilder<T> Query => new SpecificationBuilder<T>(this);
+    protected virtual IInMemorySpecificationEvaluator Evaluator => InMemorySpecificationEvaluator.Default;
+    protected virtual ISpecificationValidator Validator => SpecificationValidator.Default;
 
     /// <inheritdoc/>
-    public virtual IEnumerable<T> Evaluate(IEnumerable<T> entities)
-    {
-        return Evaluator.Evaluate(entities, this);
-    }
-
-    /// <inheritdoc/>
-    public virtual bool IsSatisfiedBy(T entity)
-    {
-        return Validator.IsValid(entity, this);
-    }
-
-    /// <inheritdoc/>
-    public IDictionary<string, object> Items { get; set; } = new Dictionary<string, object>();
-
-    /// <inheritdoc/>
-    public IEnumerable<WhereExpressionInfo<T>> WhereExpressions { get; } = new List<WhereExpressionInfo<T>>();
-
-    public IEnumerable<OrderExpressionInfo<T>> OrderExpressions { get; } = new List<OrderExpressionInfo<T>>();
-
-    /// <inheritdoc/>
-    public IEnumerable<IncludeExpressionInfo> IncludeExpressions { get; } = new List<IncludeExpressionInfo>();
-
-    /// <inheritdoc/>
-    public IEnumerable<string> IncludeStrings { get; } = new List<string>();
-
-    /// <inheritdoc/>
-    public IEnumerable<SearchExpressionInfo<T>> SearchCriterias { get; } = new List<SearchExpressionInfo<T>>();
-
-    /// <inheritdoc/>
-    public int? Take { get; internal set; } = null;
-
-    /// <inheritdoc/>
-    public int? Skip { get; internal set; } = null;
-
-    /// <inheritdoc/>
-    public Func<IEnumerable<T>, IEnumerable<T>>? PostProcessingAction { get; internal set; } = null;
+    public Func<IEnumerable<T>, IEnumerable<T>>? PostProcessingAction { get; internal set; }
 
     /// <inheritdoc/>
     public string? CacheKey { get; internal set; }
 
     /// <inheritdoc/>
-    public bool CacheEnabled { get; internal set; }
+    public bool CacheEnabled => CacheKey is not null;
 
     /// <inheritdoc/>
-    public bool AsTracking { get; internal set; } = false;
+    public int Take { get; internal set; } = -1;
 
     /// <inheritdoc/>
-    public bool AsNoTracking { get; internal set; } = false;
+    public int Skip { get; internal set; } = -1;
+
+
+    // We may store all the flags in a single byte. But, based on the object alignment of 8 bytes, we won't save any space anyway.
+    // And we'll have unnecessary overhead with enum flags for now. This will be reconsidered for version 10.
+    // Based on the alignment of 8 bytes (on x64) we can store 8 flags here. So, we have space for 3 more flags for free.
+
+    /// <inheritdoc/>
+    public bool IgnoreQueryFilters { get; internal set; } = false;
 
     /// <inheritdoc/>
     public bool AsSplitQuery { get; internal set; } = false;
 
     /// <inheritdoc/>
-    public bool AsNoTrackingWithIdentityResolution { get; internal set; } = false;
+    public bool AsNoTracking { get; internal set; } = false;
 
     /// <inheritdoc/>
-    public bool IgnoreQueryFilters { get; internal set; } = false;
+    public bool AsTracking { get; internal set; } = false;
+
+    /// <inheritdoc/>
+    public bool AsNoTrackingWithIdentityResolution { get; internal set; } = false;
+
+
+    // Specs are not intended to be thread-safe, so we don't need to worry about thread-safety here.
+    internal void Add(WhereExpressionInfo<T> whereExpression) => (_whereExpressions ??= new(2)).Add(whereExpression);
+    internal void Add(SearchExpressionInfo<T> searchExpression) => (_searchExpressions ??= new(2)).Add(searchExpression);
+    internal void Add(OrderExpressionInfo<T> orderExpression) => (_orderExpressions ??= new(2)).Add(orderExpression);
+    internal void Add(IncludeExpressionInfo includeExpression) => (_includeExpressions ??= new(2)).Add(includeExpression);
+    internal void Add(string includeString) => (_includeStrings ??= new(1)).Add(includeString);
+
+    /// <inheritdoc/>
+    public Dictionary<string, object> Items => _items ??= [];
+
+    /// <inheritdoc/>
+    public IEnumerable<WhereExpressionInfo<T>> WhereExpressions => _whereExpressions ?? Enumerable.Empty<WhereExpressionInfo<T>>();
+
+    /// <inheritdoc/>
+    public IEnumerable<SearchExpressionInfo<T>> SearchCriterias => _searchExpressions ?? Enumerable.Empty<SearchExpressionInfo<T>>();
+
+    /// <inheritdoc/>
+    public IEnumerable<OrderExpressionInfo<T>> OrderExpressions => _orderExpressions ?? Enumerable.Empty<OrderExpressionInfo<T>>();
+
+    /// <inheritdoc/>
+    public IEnumerable<IncludeExpressionInfo> IncludeExpressions => _includeExpressions ?? Enumerable.Empty<IncludeExpressionInfo>();
+
+    /// <inheritdoc/>
+    public IEnumerable<string> IncludeStrings => _includeStrings ?? Enumerable.Empty<string>();
+
+    /// <inheritdoc/>
+    public virtual IEnumerable<T> Evaluate(IEnumerable<T> entities)
+    {
+        var evaluator = Evaluator;
+        return evaluator.Evaluate(entities, this);
+    }
+
+    /// <inheritdoc/>
+    public virtual bool IsSatisfiedBy(T entity)
+    {
+        var validator = Validator;
+        return validator.IsValid(entity, this);
+    }
 }

--- a/tests/Ardalis.Specification.Tests/Ardalis.Specification.Tests.csproj
+++ b/tests/Ardalis.Specification.Tests/Ardalis.Specification.Tests.csproj
@@ -10,6 +10,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageReference Include="ManagedObjectSize.ObjectPool" />
+  </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\..\src\Ardalis.Specification\Ardalis.Specification.csproj" />

--- a/tests/Ardalis.Specification.Tests/Builders/Builder_Skip.cs
+++ b/tests/Ardalis.Specification.Tests/Builders/Builder_Skip.cs
@@ -10,8 +10,8 @@ public class Builder_Skip
         var spec1 = new Specification<Customer>();
         var spec2 = new Specification<Customer, string>();
 
-        spec1.Skip.Should().BeNull();
-        spec2.Skip.Should().BeNull();
+        spec1.Skip.Should().Be(-1);
+        spec2.Skip.Should().Be(-1);
     }
 
     [Fact]
@@ -27,8 +27,8 @@ public class Builder_Skip
         spec2.Query
             .Skip(skip, false);
 
-        spec1.Skip.Should().BeNull();
-        spec2.Skip.Should().BeNull();
+        spec1.Skip.Should().Be(-1);
+        spec2.Skip.Should().Be(-1);
     }
 
     [Fact]

--- a/tests/Ardalis.Specification.Tests/Builders/Builder_Take.cs
+++ b/tests/Ardalis.Specification.Tests/Builders/Builder_Take.cs
@@ -10,8 +10,8 @@ public class Builder_Take
         var spec1 = new Specification<Customer>();
         var spec2 = new Specification<Customer, string>();
 
-        spec1.Take.Should().BeNull();
-        spec2.Take.Should().BeNull();
+        spec1.Take.Should().Be(-1);
+        spec2.Take.Should().Be(-1);
     }
 
     [Fact]
@@ -27,8 +27,8 @@ public class Builder_Take
         spec2.Query
             .Take(take, false);
 
-        spec1.Take.Should().BeNull();
-        spec2.Take.Should().BeNull();
+        spec1.Take.Should().Be(-1);
+        spec2.Take.Should().Be(-1);
     }
 
     [Fact]

--- a/tests/Ardalis.Specification.Tests/SpecificationSizeTests.cs
+++ b/tests/Ardalis.Specification.Tests/SpecificationSizeTests.cs
@@ -1,0 +1,40 @@
+﻿#if NET8_0_OR_GREATER
+
+using ManagedObjectSize;
+using System.Runtime.CompilerServices;
+using Xunit.Abstractions;
+
+namespace Tests;
+
+public class SpecificationSizeTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public SpecificationSizeTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void Spec_Empty()
+    {
+        var spec = new Specification<Customer>();
+
+        var size = ObjectSize.GetObjectInclusiveSize(spec);
+
+        size.Should().BeLessThan(100);
+        PrintObjectSize(spec);
+    }
+
+    private record Customer(int id);
+
+    private void PrintObjectSize(object obj, [CallerArgumentExpression(nameof(obj))] string caller = "")
+    {
+        _output.WriteLine("");
+        _output.WriteLine(caller);
+        _output.WriteLine($"Inclusive: {ObjectSize.GetObjectInclusiveSize(obj):N0}");
+        _output.WriteLine($"Exclusive: {ObjectSize.GetObjectExclusiveSize(obj):N0}");
+    }
+}
+
+#endif


### PR DESCRIPTION
Fixes #415 #416 #417 #418 

TLDR: The size of an empty is reduced to 96 bytes, from 392 bytes. 