### PR TITLE
Fix type inference for ThenInclude with casting.

### DIFF
--- a/src/Ardalis.Specification/Builders/Builder_Include.cs
+++ b/src/Ardalis.Specification/Builders/Builder_Include.cs
@@ -101,7 +101,7 @@ public static partial class SpecificationBuilderExtensions
     {
         if (condition)
         {
-            var expr = new IncludeExpressionInfo(navigationSelector, IncludeTypeEnum.Include);
+            var expr = new IncludeExpressionInfo(navigationSelector);
             builder.Specification.Add(expr);
         }
 
@@ -139,7 +139,7 @@ public static partial class SpecificationBuilderExtensions
     {
         if (condition)
         {
-            var expr = new IncludeExpressionInfo(navigationSelector, IncludeTypeEnum.Include);
+            var expr = new IncludeExpressionInfo(navigationSelector);
             builder.Specification.Add(expr);
         }
 
@@ -183,7 +183,7 @@ public static partial class SpecificationBuilderExtensions
     {
         if (condition && !Specification<TEntity>.IsChainDiscarded)
         {
-            var expr = new IncludeExpressionInfo(navigationSelector, IncludeTypeEnum.ThenInclude);
+            var expr = new IncludeExpressionInfo(navigationSelector, typeof(TPreviousProperty));
             builder.Specification.Add(expr);
         }
         else
@@ -228,7 +228,7 @@ public static partial class SpecificationBuilderExtensions
     {
         if (condition && !Specification<TEntity>.IsChainDiscarded)
         {
-            var expr = new IncludeExpressionInfo(navigationSelector, IncludeTypeEnum.ThenInclude);
+            var expr = new IncludeExpressionInfo(navigationSelector, typeof(TPreviousProperty));
             builder.Specification.Add(expr);
         }
         else
@@ -275,7 +275,7 @@ public static partial class SpecificationBuilderExtensions
     {
         if (condition && !Specification<TEntity>.IsChainDiscarded)
         {
-            var expr = new IncludeExpressionInfo(navigationSelector, IncludeTypeEnum.ThenInclude);
+            var expr = new IncludeExpressionInfo(navigationSelector, typeof(IEnumerable<TPreviousProperty>));
             builder.Specification.Add(expr);
         }
         else
@@ -320,7 +320,7 @@ public static partial class SpecificationBuilderExtensions
     {
         if (condition && !Specification<TEntity>.IsChainDiscarded)
         {
-            var expr = new IncludeExpressionInfo(navigationSelector, IncludeTypeEnum.ThenInclude);
+            var expr = new IncludeExpressionInfo(navigationSelector, typeof(IEnumerable<TPreviousProperty>));
             builder.Specification.Add(expr);
         }
         else

--- a/src/Ardalis.Specification/Expressions/IncludeExpressionInfo.cs
+++ b/src/Ardalis.Specification/Expressions/IncludeExpressionInfo.cs
@@ -12,15 +12,31 @@ public class IncludeExpressionInfo
     public LambdaExpression LambdaExpression { get; }
 
     /// <summary>
+    /// The type of the previously included entity.
+    /// </summary>
+    public Type? PreviousPropertyType { get; }
+
+    /// <summary>
     /// The include type.
     /// </summary>
     public IncludeTypeEnum Type { get; }
 
-    public IncludeExpressionInfo(LambdaExpression expression, IncludeTypeEnum includeType)
+    public IncludeExpressionInfo(LambdaExpression expression)
     {
         _ = expression ?? throw new ArgumentNullException(nameof(expression));
 
         LambdaExpression = expression;
-        Type = includeType;
+        PreviousPropertyType = null;
+        Type = IncludeTypeEnum.Include;
+    }
+
+    public IncludeExpressionInfo(LambdaExpression expression, Type previousPropertyType)
+    {
+        _ = expression ?? throw new ArgumentNullException(nameof(expression));
+        _ = previousPropertyType ?? throw new ArgumentNullException(nameof(previousPropertyType));
+
+        LambdaExpression = expression;
+        PreviousPropertyType = previousPropertyType;
+        Type = IncludeTypeEnum.ThenInclude;
     }
 }

--- a/tests/Ardalis.Specification.EntityFrameworkCore.Tests/Evaluators/IncludeEvaluatorTests.cs
+++ b/tests/Ardalis.Specification.EntityFrameworkCore.Tests/Evaluators/IncludeEvaluatorTests.cs
@@ -35,7 +35,7 @@ public class IncludeEvaluatorTests(TestFactory factory) : IntegrationTest(factor
         var spec = new Specification<Bar>();
         spec.Query
             .Include(x => x.BarChildren)
-            .ThenInclude<Bar, BarChild, BarDerivedInfo>(x => (x as BarDerived)!.BarDerivedInfo);
+            .ThenInclude(x => (x as BarDerived)!.BarDerivedInfo);
 
         var actual = _evaluator
             .GetQuery(DbContext.Bars, spec)

--- a/tests/Ardalis.Specification.Tests/Expressions/IncludeExpressionInfoTests.cs
+++ b/tests/Ardalis.Specification.Tests/Expressions/IncludeExpressionInfoTests.cs
@@ -9,18 +9,44 @@ public class IncludeExpressionInfoTests
     [Fact]
     public void Constructor_ThrowsArgumentNullException_GivenNullForLambdaExpression()
     {
-        var sut = () => new IncludeExpressionInfo(null!, IncludeTypeEnum.Include);
+        var sut = () => new IncludeExpressionInfo(null!);
 
         sut.Should().Throw<ArgumentNullException>().WithParameterName("expression");
+
+
+        sut = () => new IncludeExpressionInfo(null!, typeof(Customer));
+
+        sut.Should().Throw<ArgumentNullException>().WithParameterName("expression");
+    }
+
+    [Fact]
+    public void Constructor_ThrowsArgumentNullException_GivenNullForPreviousPropertyType()
+    {
+        Expression<Func<Customer, Address>> expr = x => x.Address;
+        var sut = () => new IncludeExpressionInfo(expr, null!);
+
+        sut.Should().Throw<ArgumentNullException>().WithParameterName("previousPropertyType");
     }
 
     [Fact]
     public void Constructor_GivenIncludeExpression()
     {
         Expression<Func<Customer, Address>> expr = x => x.Address;
-        var sut = new IncludeExpressionInfo(expr, IncludeTypeEnum.Include);
+        var sut = new IncludeExpressionInfo(expr);
 
         sut.Type.Should().Be(IncludeTypeEnum.Include);
         sut.LambdaExpression.Should().Be(expr);
+    }
+
+    [Fact]
+    public void Constructor_GivenThenIncludeExpressionAndPreviousPropertyType()
+    {
+        Expression<Func<Address, City>> expr = x => x.City;
+        var previousPropertyType = typeof(Customer);
+        var sut = new IncludeExpressionInfo(expr, previousPropertyType);
+
+        sut.Type.Should().Be(IncludeTypeEnum.ThenInclude);
+        sut.LambdaExpression.Should().Be(expr);
+        sut.PreviousPropertyType.Should().Be(previousPropertyType);
     }
 }


### PR DESCRIPTION
Fixes #463 

There is an ongoing inconsistency in EF (described in the related issue). For now, we won't infer the previous property type from LambdaExpression, we'll keep it as a state in `IncludeExpressionInfo`.

The constructors of the `IncludeExpressionInfo` are modified, so that might be a breaking change for anyone using it directly.