### PR TITLE
Add support for multiple TagWith

### DIFF
--- a/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/TagWithEvaluator.cs
+++ b/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/TagWithEvaluator.cs
@@ -9,9 +9,9 @@ public class TagWithEvaluator : IEvaluator
 
     public IQueryable<T> GetQuery<T>(IQueryable<T> query, ISpecification<T> specification) where T : class
     {
-        if (specification.QueryTag is not null)
+        foreach (var tag in specification.QueryTags)
         {
-            query = query.TagWith(specification.QueryTag);
+            query = query.TagWith(tag);
         }
 
         return query;

--- a/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/TagWithEvaluator.cs
+++ b/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/TagWithEvaluator.cs
@@ -9,9 +9,18 @@ public class TagWithEvaluator : IEvaluator
 
     public IQueryable<T> GetQuery<T>(IQueryable<T> query, ISpecification<T> specification) where T : class
     {
-        foreach (var tag in specification.QueryTags)
+        if (specification.OneOrManyQueryTags.IsEmpty) return query;
+
+        if (specification.OneOrManyQueryTags.IsSingle)
         {
-            query = query.TagWith(tag);
+            query = query.TagWith(specification.OneOrManyQueryTags.Single);
+        }
+        else
+        {
+            foreach (var tag in specification.OneOrManyQueryTags.Values)
+            {
+                query = query.TagWith(tag);
+            }
         }
 
         return query;

--- a/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/TagWithEvaluator.cs
+++ b/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/TagWithEvaluator.cs
@@ -9,18 +9,20 @@ public class TagWithEvaluator : IEvaluator
 
     public IQueryable<T> GetQuery<T>(IQueryable<T> query, ISpecification<T> specification) where T : class
     {
-        if (specification.OneOrManyQueryTags.IsEmpty) return query;
+        if (specification is Specification<T> spec)
+        {
+            if (spec.OneOrManyQueryTags.IsEmpty) return query;
 
-        if (specification.OneOrManyQueryTags.IsSingle)
-        {
-            query = query.TagWith(specification.OneOrManyQueryTags.Single);
-        }
-        else
-        {
-            foreach (var tag in specification.OneOrManyQueryTags.Values)
+            if (spec.OneOrManyQueryTags.HasSingleItem)
             {
-                query = query.TagWith(tag);
+                query = query.TagWith(spec.OneOrManyQueryTags.Single);
+                return query;
             }
+        }
+
+        foreach (var tag in specification.QueryTags)
+        {
+            query = query.TagWith(tag);
         }
 
         return query;

--- a/src/Ardalis.Specification/Ardalis.Specification.csproj
+++ b/src/Ardalis.Specification/Ardalis.Specification.csproj
@@ -23,4 +23,10 @@
     <PackageReference Include="System.Memory" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Ardalis.Specification.EntityFrameworkCore" />
+    <InternalsVisibleTo Include="Ardalis.Specification.EntityFramework6" />
+    <InternalsVisibleTo Include="Ardalis.Specification.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Ardalis.Specification/Builders/Builder_TagWith.cs
+++ b/src/Ardalis.Specification/Builders/Builder_TagWith.cs
@@ -63,7 +63,7 @@ public static partial class SpecificationBuilderExtensions
     {
         if (condition)
         {
-            builder.Specification.QueryTag = tag;
+            builder.Specification.AddQueryTag(tag);
         }
 
         return builder;

--- a/src/Ardalis.Specification/ISpecification.cs
+++ b/src/Ardalis.Specification/ISpecification.cs
@@ -84,9 +84,9 @@ public interface ISpecification<T>
     Func<IEnumerable<T>, IEnumerable<T>>? PostProcessingAction { get; }
 
     /// <summary>
-    /// A query tag to help correlate specification with generated SQL queries captured in logs
+    /// A query tags to help correlate specification with generated SQL queries captured in logs
     /// </summary>
-    string? QueryTag { get; }
+    IEnumerable<string> QueryTags { get; }
 
     /// <summary>
     /// Return whether or not the results should be cached.

--- a/src/Ardalis.Specification/ISpecification.cs
+++ b/src/Ardalis.Specification/ISpecification.cs
@@ -86,12 +86,13 @@ public interface ISpecification<T>
     Func<IEnumerable<T>, IEnumerable<T>>? PostProcessingAction { get; }
 
     /// <summary>
-    /// A query tags to help correlate specification with generated SQL queries captured in logs
+    /// Query tags to help correlate specification with generated SQL queries captured in logs.
     /// </summary>
     IEnumerable<string> QueryTags { get; }
 
     /// <summary>
-    /// A query tags to help correlate specification with generated SQL queries captured in logs
+    /// Query tags to help correlate specification with generated SQL queries captured in logs.
+    /// Gets the query tags, which can be a single tag or multiple tags.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public OneOrMany<string> OneOrManyQueryTags { get; }

--- a/src/Ardalis.Specification/ISpecification.cs
+++ b/src/Ardalis.Specification/ISpecification.cs
@@ -1,4 +1,6 @@
-﻿namespace Ardalis.Specification;
+﻿using System.ComponentModel;
+
+namespace Ardalis.Specification;
 
 /// <summary>
 /// Encapsulates query logic for <typeparamref name="T"/>,
@@ -87,6 +89,12 @@ public interface ISpecification<T>
     /// A query tags to help correlate specification with generated SQL queries captured in logs
     /// </summary>
     IEnumerable<string> QueryTags { get; }
+
+    /// <summary>
+    /// A query tags to help correlate specification with generated SQL queries captured in logs
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public OneOrMany<string> OneOrManyQueryTags { get; }
 
     /// <summary>
     /// Return whether or not the results should be cached.

--- a/src/Ardalis.Specification/ISpecification.cs
+++ b/src/Ardalis.Specification/ISpecification.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel;
-
-namespace Ardalis.Specification;
+﻿namespace Ardalis.Specification;
 
 /// <summary>
 /// Encapsulates query logic for <typeparamref name="T"/>,

--- a/src/Ardalis.Specification/ISpecification.cs
+++ b/src/Ardalis.Specification/ISpecification.cs
@@ -91,13 +91,6 @@ public interface ISpecification<T>
     IEnumerable<string> QueryTags { get; }
 
     /// <summary>
-    /// Query tags to help correlate specification with generated SQL queries captured in logs.
-    /// Gets the query tags, which can be a single tag or multiple tags.
-    /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public OneOrMany<string> OneOrManyQueryTags { get; }
-
-    /// <summary>
     /// Return whether or not the results should be cached.
     /// </summary>
     bool CacheEnabled { get; }

--- a/src/Ardalis.Specification/Internals/OneOrMany.cs
+++ b/src/Ardalis.Specification/Internals/OneOrMany.cs
@@ -1,12 +1,11 @@
 ﻿namespace Ardalis.Specification;
 
-public struct OneOrMany<T>
+internal struct OneOrMany<T>
 {
     private object? _value;
 
-    public readonly bool IsSingle => _value is T;
-    public readonly bool IsMultiple => _value is List<T>;
-    public readonly bool IsEmpty => _value is null || (_value is List<T> list && list.Count == 0);
+    public readonly bool IsEmpty => _value is null;
+    public readonly bool HasSingleItem => _value is T;
 
     public void Add(T item)
     {
@@ -38,12 +37,7 @@ public struct OneOrMany<T>
                 return singleValue;
             }
 
-            if (_value is List<T> multipleValues && multipleValues.Count == 1)
-            {
-                return multipleValues[0];
-            }
-
-            throw new InvalidOperationException("The value is not a single item or a list with exactly one item.");
+            throw new InvalidOperationException("The value is not a single item.");
         }
     }
 

--- a/src/Ardalis.Specification/OneOrMany.cs
+++ b/src/Ardalis.Specification/OneOrMany.cs
@@ -1,0 +1,88 @@
+﻿namespace Ardalis.Specification;
+
+public struct OneOrMany<T>
+{
+    private object? _value;
+
+    public readonly bool IsSingle => _value is T;
+    public readonly bool IsMultiple => _value is List<T>;
+    public readonly bool IsEmpty => _value is null || (_value is List<T> list && list.Count == 0);
+
+    public void Add(T item)
+    {
+        if (_value is null)
+        {
+            _value = item;
+            return;
+        }
+
+        if (_value is List<T> list)
+        {
+            list.Add(item);
+            return;
+        }
+
+        if (_value is T singleValue)
+        {
+            _value = new List<T>(2) { singleValue, item };
+            return;
+        }
+    }
+
+    public readonly T Single
+    {
+        get
+        {
+            if (_value is T singleValue)
+            {
+                return singleValue;
+            }
+
+            if (_value is List<T> multipleValues && multipleValues.Count == 1)
+            {
+                return multipleValues[0];
+            }
+
+            throw new InvalidOperationException("The value is not a single item or a list with exactly one item.");
+        }
+    }
+
+    public readonly IEnumerable<T> Values
+    {
+        get
+        {
+            if (_value is null)
+            {
+                return Enumerable.Empty<T>();
+            }
+
+            if (_value is List<T> tags)
+            {
+                return tags;
+            }
+
+            if (_value is T singleValue)
+            {
+                return new[] { singleValue };
+            }
+
+            throw new InvalidOperationException("The value is neither a single item nor a list of items.");
+        }
+    }
+
+    public readonly OneOrMany<T> Clone()
+    {
+        var clone = new OneOrMany<T>();
+
+        if (_value is T singleValue)
+        {
+            clone._value = singleValue;
+        }
+        else if (_value is List<T> list)
+        {
+            clone._value = list.ToList();
+        }
+
+        return clone;
+    }
+}

--- a/src/Ardalis.Specification/Specification.cs
+++ b/src/Ardalis.Specification/Specification.cs
@@ -172,12 +172,7 @@ public class Specification<T> : ISpecification<T>
                 return tags;
             }
 
-            return SingleTag(_queryTags);
-
-            static IEnumerable<string> SingleTag(object tag)
-            {
-                yield return (string)tag;
-            }
+            return new string[] { (string)_queryTags };
         }
     }
 

--- a/src/Ardalis.Specification/Specification.cs
+++ b/src/Ardalis.Specification/Specification.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel;
-using System.Diagnostics;
 
 namespace Ardalis.Specification;
 

--- a/src/Ardalis.Specification/Specification.cs
+++ b/src/Ardalis.Specification/Specification.cs
@@ -142,9 +142,7 @@ public class Specification<T> : ISpecification<T>
     /// <inheritdoc/>
     public IEnumerable<string> QueryTags => _queryTags.Values;
 
-    /// <inheritdoc/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public OneOrMany<string> OneOrManyQueryTags => _queryTags;
+    internal OneOrMany<string> OneOrManyQueryTags => _queryTags;
 
     /// <inheritdoc/>
     public virtual IEnumerable<T> Evaluate(IEnumerable<T> entities)

--- a/tests/Ardalis.Specification.EntityFrameworkCore.Tests/Evaluators/TagWithEvaluatorTests.cs
+++ b/tests/Ardalis.Specification.EntityFrameworkCore.Tests/Evaluators/TagWithEvaluatorTests.cs
@@ -24,6 +24,45 @@ public class TagWithEvaluatorTests(TestFactory factory) : IntegrationTest(factor
     }
 
     [Fact]
+    public void QueriesMatch_GivenMultipleTags()
+    {
+        var tag1 = "asd";
+        var tag2 = "qwe";
+
+        var spec = new Specification<Country>();
+        spec.Query.TagWith(tag1);
+        spec.Query.TagWith(tag2);
+
+        var actual = _evaluator.GetQuery(DbContext.Countries, spec)
+            .ToQueryString();
+
+        var expected = DbContext.Countries
+            .TagWith(tag1)
+            .TagWith(tag2)
+            .ToQueryString();
+
+        actual.Should().Be(expected);
+    }
+
+
+    [Fact]
+    public void DoesNothing_GivenNoTag()
+    {
+        var spec = new Specification<Country>();
+
+        var actual = _evaluator.GetQuery(DbContext.Countries, spec)
+            .Expression
+            .ToString();
+
+        var expected = DbContext.Countries
+            .AsQueryable()
+            .Expression
+            .ToString();
+
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
     public void Applies_GivenSingleTag()
     {
         var tag = "asd";

--- a/tests/Ardalis.Specification.EntityFrameworkCore.Tests/Evaluators/TagWithEvaluatorTests.cs
+++ b/tests/Ardalis.Specification.EntityFrameworkCore.Tests/Evaluators/TagWithEvaluatorTests.cs
@@ -24,7 +24,7 @@ public class TagWithEvaluatorTests(TestFactory factory) : IntegrationTest(factor
     }
 
     [Fact]
-    public void Applies_GivenTag()
+    public void Applies_GivenSingleTag()
     {
         var tag = "asd";
 
@@ -37,6 +37,57 @@ public class TagWithEvaluatorTests(TestFactory factory) : IntegrationTest(factor
 
         var expected = DbContext.Countries
             .TagWith(tag)
+            .Expression
+            .ToString();
+
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Applies_GivenTwoTags()
+    {
+        var tag1 = "asd";
+        var tag2 = "qwe";
+
+        var spec = new Specification<Country>();
+        spec.Query
+            .TagWith(tag1)
+            .TagWith(tag2);
+
+        var actual = _evaluator.GetQuery(DbContext.Countries, spec)
+            .Expression
+            .ToString();
+
+        var expected = DbContext.Countries
+            .TagWith(tag1)
+            .TagWith(tag2)
+            .Expression
+            .ToString();
+
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Applies_GivenMultipleTags()
+    {
+        var tag1 = "asd";
+        var tag2 = "qwe";
+        var tag3 = "zxc";
+
+        var spec = new Specification<Country>();
+        spec.Query
+            .TagWith(tag1)
+            .TagWith(tag2)
+            .TagWith(tag3);
+
+        var actual = _evaluator.GetQuery(DbContext.Countries, spec)
+            .Expression
+            .ToString();
+
+        var expected = DbContext.Countries
+            .TagWith(tag1)
+            .TagWith(tag2)
+            .TagWith(tag3)
             .Expression
             .ToString();
 

--- a/tests/Ardalis.Specification.Tests/Builders/Builder_TagWith.cs
+++ b/tests/Ardalis.Specification.Tests/Builders/Builder_TagWith.cs
@@ -10,8 +10,8 @@ public class Builder_TagWith
         var spec1 = new Specification<Customer>();
         var spec2 = new Specification<Customer, string>();
 
-        spec1.QueryTag.Should().BeNull();
-        spec2.QueryTag.Should().BeNull();
+        spec1.QueryTags.Should().BeSameAs(Enumerable.Empty<string>());
+        spec2.QueryTags.Should().BeSameAs(Enumerable.Empty<string>());
     }
 
     [Fact]
@@ -25,12 +25,12 @@ public class Builder_TagWith
         spec2.Query
             .TagWith("asd", false);
 
-        spec1.QueryTag.Should().BeNull();
-        spec2.QueryTag.Should().BeNull();
+        spec1.QueryTags.Should().BeSameAs(Enumerable.Empty<string>());
+        spec2.QueryTags.Should().BeSameAs(Enumerable.Empty<string>());
     }
 
     [Fact]
-    public void SetsTag_GivenTag()
+    public void SetsTag_GivenSingleTag()
     {
         var tag = "asd";
 
@@ -42,7 +42,63 @@ public class Builder_TagWith
         spec2.Query
             .TagWith(tag);
 
-        spec1.QueryTag.Should().Be(tag);
-        spec2.QueryTag.Should().Be(tag);
+        spec1.QueryTags.Should().ContainSingle();
+        spec1.QueryTags.First().Should().Be(tag);
+        spec2.QueryTags.Should().ContainSingle();
+        spec2.QueryTags.First().Should().Be(tag);
+    }
+
+    [Fact]
+    public void SetsTags_GivenTwoTags()
+    {
+        var tag1 = "asd";
+        var tag2 = "qwe";
+
+        var spec1 = new Specification<Customer>();
+        spec1.Query
+            .TagWith(tag1)
+            .TagWith(tag2);
+
+        var spec2 = new Specification<Customer, string>();
+        spec2.Query
+            .TagWith(tag1)
+            .TagWith(tag2);
+
+        spec1.QueryTags.Should().HaveCount(2);
+        spec1.QueryTags.First().Should().Be(tag1);
+        spec1.QueryTags.Skip(1).First().Should().Be(tag2);
+        spec2.QueryTags.Should().HaveCount(2);
+        spec2.QueryTags.First().Should().Be(tag1);
+        spec2.QueryTags.Skip(1).First().Should().Be(tag2);
+    }
+
+    [Fact]
+    public void SetsTags_GivenMultipleTags()
+    {
+        var tag1 = "asd";
+        var tag2 = "qwe";
+        var tag3 = "zxc";
+
+        var spec1 = new Specification<Customer>();
+        spec1.Query
+            .TagWith(tag1)
+            .TagWith(tag2)
+            .TagWith(tag3);
+
+        var spec2 = new Specification<Customer, string>();
+        spec2.Query
+            .TagWith(tag1)
+            .TagWith(tag2)
+            .TagWith(tag3);
+
+        spec1.QueryTags.Should().HaveCount(3);
+        spec1.QueryTags.First().Should().Be(tag1);
+        spec1.QueryTags.Skip(1).First().Should().Be(tag2);
+        spec1.QueryTags.Skip(2).First().Should().Be(tag3);
+
+        spec2.QueryTags.Should().HaveCount(3);
+        spec2.QueryTags.First().Should().Be(tag1);
+        spec2.QueryTags.Skip(1).First().Should().Be(tag2);
+        spec2.QueryTags.Skip(2).First().Should().Be(tag3);
     }
 }

--- a/tests/Ardalis.Specification.Tests/Internals/OneOrManyTests.cs
+++ b/tests/Ardalis.Specification.Tests/Internals/OneOrManyTests.cs
@@ -1,0 +1,205 @@
+﻿#if NET8_0_OR_GREATER
+
+namespace Tests.Internals;
+
+public class OneOrManyTests
+{
+    [Fact]
+    public void IsEmpty_ReturnTrue_GivenEmptyStruct()
+    {
+        var oneOrMany = new OneOrMany<string>();
+
+        oneOrMany.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEmpty_ReturnFalse_GivenItems()
+    {
+        var oneOrMany = new OneOrMany<string>();
+        Accessors.ValueOf(ref oneOrMany) = "foo";
+
+        oneOrMany.IsEmpty.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasSingleItem_ReturnFalse_GivenEmptyStruct()
+    {
+        var oneOrMany = new OneOrMany<string>();
+
+        oneOrMany.HasSingleItem.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasSingleItem_ReturnTrue_GivenSingleItem()
+    {
+        var oneOrMany = new OneOrMany<string>();
+        Accessors.ValueOf(ref oneOrMany) = "foo";
+
+        oneOrMany.HasSingleItem.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasSingleItem_ReturnFalse_GivenMultipleItems()
+    {
+        var oneOrMany = new OneOrMany<string>();
+        Accessors.ValueOf(ref oneOrMany) = new List<string> { "foo", "bar" };
+
+        oneOrMany.HasSingleItem.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Add_CreatesSingleItem_GivenEmptyStruct()
+    {
+        var oneOrMany = new OneOrMany<string>();
+        oneOrMany.Add("foo");
+
+        var value = Accessors.ValueOf(ref oneOrMany);
+        value.Should().BeOfType<string>();
+        value.Should().Be("foo");
+    }
+
+    [Fact]
+    public void Add_CreatesListWithTwoItems_GivenSingleItem()
+    {
+        var oneOrMany = new OneOrMany<string>();
+        Accessors.ValueOf(ref oneOrMany) = "foo";
+
+        oneOrMany.Add("bar");
+
+        var value = Accessors.ValueOf(ref oneOrMany);
+        value.Should().BeOfType<List<string>>();
+        value.Should().BeEquivalentTo(new List<string> { "foo", "bar" });
+    }
+
+    [Fact]
+    public void Add_AddsToTheList_GivenTwoItems()
+    {
+        var oneOrMany = new OneOrMany<string>();
+        Accessors.ValueOf(ref oneOrMany) = new List<string> { "foo", "bar" };
+
+        oneOrMany.Add("baz");
+
+        var value = Accessors.ValueOf(ref oneOrMany);
+        value.Should().BeOfType<List<string>>();
+        value.Should().BeEquivalentTo(new List<string> { "foo", "bar", "baz" });
+    }
+
+    [Fact]
+    public void Add_DoesNothing_GivenInvalidState()
+    {
+        var oneOrMany = new OneOrMany<string>();
+        Accessors.ValueOf(ref oneOrMany) = new string[] { "foo", "bar" };
+
+        oneOrMany.Add("baz");
+
+        var value = Accessors.ValueOf(ref oneOrMany);
+        value.Should().BeOfType<string[]>();
+        value.Should().BeEquivalentTo(new string[] { "foo", "bar" });
+    }
+
+    [Fact]
+    public void Single_ReturnsSingleItem_GivenSingleItem()
+    {
+        var oneOrMany = new OneOrMany<string>();
+        Accessors.ValueOf(ref oneOrMany) = "foo";
+
+        oneOrMany.Single.Should().Be("foo");
+    }
+
+    [Fact]
+    public void Single_Throws_GivenEmptyStruct()
+    {
+        var oneOrMany = new OneOrMany<string>();
+
+        var action = () => oneOrMany.Single;
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Single_Throws_GivenMultipleItems()
+    {
+        var oneOrMany = new OneOrMany<string>();
+        Accessors.ValueOf(ref oneOrMany) = new string[] { "foo", "bar" };
+
+        var action = () => _ = oneOrMany.Single;
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Values_ReturnsEmpty_GivenEmptyStruct()
+    {
+        var oneOrMany = new OneOrMany<string>();
+
+        oneOrMany.Values.Should().BeEmpty();
+        oneOrMany.Values.Should().BeSameAs(Enumerable.Empty<string>());
+    }
+
+    [Fact]
+    public void Values_ReturnsSingleItemEnumerable_GivenSingleItem()
+    {
+        var oneOrMany = new OneOrMany<string>();
+        Accessors.ValueOf(ref oneOrMany) = "foo";
+
+        oneOrMany.Values.Should().ContainSingle();
+        oneOrMany.Values.Should().BeEquivalentTo(new List<string> { "foo" });
+    }
+
+    [Fact]
+    public void Values_ReturnsEnumerable_GivenMultipleItems()
+    {
+        var oneOrMany = new OneOrMany<string>();
+        Accessors.ValueOf(ref oneOrMany) = new List<string> { "foo", "bar" };
+
+        oneOrMany.Values.Should().BeEquivalentTo(new List<string> { "foo", "bar" });
+    }
+
+    [Fact]
+    public void Values_Throws_GivenInvalidState()
+    {
+        var oneOrMany = new OneOrMany<string>();
+        Accessors.ValueOf(ref oneOrMany) = new string[] { "foo", "bar" };
+
+        var action = () => _ = oneOrMany.Values;
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Clone_ReturnEqualStruct_GivenSingleItem()
+    {
+        var oneOrMany = new OneOrMany<string>();
+        Accessors.ValueOf(ref oneOrMany) = "foo";
+
+        var clone = oneOrMany.Clone();
+
+        clone.Values.Should().BeEquivalentTo(oneOrMany.Values);
+    }
+
+    [Fact]
+    public void Clone_ReturnEqualStruct_GivenMultipleItems()
+    {
+        var oneOrMany = new OneOrMany<string>();
+        Accessors.ValueOf(ref oneOrMany) = new List<string> { "foo", "bar" };
+
+        var clone = oneOrMany.Clone();
+
+        clone.Values.Should().BeEquivalentTo(oneOrMany.Values);
+    }
+
+    [Fact]
+    public void Clone_ReturnsNewEmptyStruct_GivenEmptyStruct()
+    {
+        var oneOrMany = new OneOrMany<string>();
+
+        var clone = oneOrMany.Clone();
+
+        clone.Values.Should().BeEquivalentTo(oneOrMany.Values);
+    }
+
+    private class Accessors
+    {
+        [System.Runtime.CompilerServices.UnsafeAccessor(System.Runtime.CompilerServices.UnsafeAccessorKind.Field, Name = "_value")]
+        public static extern ref object? ValueOf(ref OneOrMany<string> @this);
+    }
+}
+
+#endif

--- a/tests/Ardalis.Specification.Tests/SpecificationExtensionsTests.cs
+++ b/tests/Ardalis.Specification.Tests/SpecificationExtensionsTests.cs
@@ -23,7 +23,7 @@ public class SpecificationExtensionsTests
             .IgnoreQueryFilters()
             .AsSplitQuery()
             .AsNoTracking()
-            .TagWith("testQuery")
+            .TagWith("testQuery1")
             .PostProcessingAction(x => x.Where(x => x.Id > 0));
 
         var projectionSpec = new Specification<Person, string>();
@@ -51,6 +51,9 @@ public class SpecificationExtensionsTests
         newSpec.SearchCriterias.Should().NotBeSameAs(spec.SearchCriterias);
         newSpec.SearchCriterias.Should().Equal(spec.SearchCriterias);
 
+        newSpec.QueryTags.Should().NotBeSameAs(spec.QueryTags);
+        newSpec.QueryTags.Should().Equal(spec.QueryTags);
+
         newSpec.Take.Should().Be(spec.Take);
         newSpec.Skip.Should().Be(spec.Skip);
         newSpec.CacheKey.Should().Be(spec.CacheKey);
@@ -60,9 +63,26 @@ public class SpecificationExtensionsTests
         newSpec.AsNoTracking.Should().Be(spec.AsNoTracking);
         newSpec.AsNoTrackingWithIdentityResolution.Should().Be(spec.AsNoTrackingWithIdentityResolution);
         newSpec.AsTracking.Should().Be(spec.AsTracking);
-        newSpec.QueryTag.Should().Be(spec.QueryTag);
 
         newSpec.PostProcessingAction.Should().BeSameAs(projectionSpec.PostProcessingAction);
         ((Specification<Person>)newSpec).PostProcessingAction.Should().BeSameAs(spec.PostProcessingAction);
+    }
+
+    [Fact]
+    public void WithProjectionOf_ReturnsCopyWithProjection_GivenSpecWithMultipleTags()
+    {
+        var spec = new Specification<Person>();
+        spec.Query
+            .TagWith("testQuery1")
+            .TagWith("testQuery2");
+
+        var projectionSpec = new Specification<Person, string>();
+        projectionSpec.Query.Select(x => x.Name);
+        projectionSpec.Query.SelectMany(x => x.Names);
+
+        var newSpec = spec.WithProjectionOf(projectionSpec);
+
+        newSpec.QueryTags.Should().NotBeSameAs(spec.QueryTags);
+        newSpec.QueryTags.Should().Equal(spec.QueryTags);
     }
 }


### PR DESCRIPTION
Fixes #468 

We could implement this by simply holding a `List<string>` state in the specification. However, the memory overhead of a non-empty list is 72 bytes (on x64). Considering that in 99% of cases, users will add a single tag, the memory overhead is unacceptable. 

Instead, we'll create and use `OneOrMany` struct implementation, which has a single `object?` state (spending only 8 bytes for the reference). The state will represent a `string` or `List<string` depending on the situation.