### PR TITLE
Avoid List allocation for PostProcessingAction.

### DIFF
--- a/src/Ardalis.Specification.EntityFramework6/Extensions/DbSetExtensions.cs
+++ b/src/Ardalis.Specification.EntityFramework6/Extensions/DbSetExtensions.cs
@@ -12,9 +12,9 @@ public static class DbSetExtensions
     {
         var result = await SpecificationEvaluator.Default.GetQuery(source, specification).ToListAsync(cancellationToken);
 
-        return specification.PostProcessingAction == null
+        return specification.PostProcessingAction is null
             ? result
-            : specification.PostProcessingAction(result).ToList();
+            : specification.PostProcessingAction(result).AsList();
     }
 
     public static async Task<IEnumerable<TSource>> ToEnumerableAsync<TSource>(
@@ -25,7 +25,7 @@ public static class DbSetExtensions
     {
         var result = await SpecificationEvaluator.Default.GetQuery(source, specification).ToListAsync(cancellationToken);
 
-        return specification.PostProcessingAction == null
+        return specification.PostProcessingAction is null
             ? result
             : specification.PostProcessingAction(result);
     }

--- a/src/Ardalis.Specification.EntityFramework6/RepositoryBaseOfT.cs
+++ b/src/Ardalis.Specification.EntityFramework6/RepositoryBaseOfT.cs
@@ -136,7 +136,9 @@ public abstract class RepositoryBase<T> : IRepositoryBase<T> where T : class
     {
         var queryResult = await ApplySpecification(specification).ToListAsync(cancellationToken);
 
-        return specification.PostProcessingAction == null ? queryResult : specification.PostProcessingAction(queryResult).ToList();
+        return specification.PostProcessingAction is null
+            ? queryResult
+            : specification.PostProcessingAction(queryResult).AsList();
     }
 
     /// <inheritdoc/>
@@ -144,7 +146,9 @@ public abstract class RepositoryBase<T> : IRepositoryBase<T> where T : class
     {
         var queryResult = await ApplySpecification(specification).ToListAsync(cancellationToken);
 
-        return specification.PostProcessingAction == null ? queryResult : specification.PostProcessingAction(queryResult).ToList();
+        return specification.PostProcessingAction is null
+            ? queryResult
+            : specification.PostProcessingAction(queryResult).AsList();
     }
 
     /// <inheritdoc/>

--- a/src/Ardalis.Specification.EntityFrameworkCore/ContextFactoryRepositoryBaseOfT.cs
+++ b/src/Ardalis.Specification.EntityFrameworkCore/ContextFactoryRepositoryBaseOfT.cs
@@ -68,7 +68,9 @@ public abstract class ContextFactoryRepositoryBaseOfT<TEntity, TContext> : IRepo
         await using var dbContext = _dbContextFactory.CreateDbContext();
         var queryResult = await ApplySpecification(specification, dbContext).ToListAsync(cancellationToken);
 
-        return specification.PostProcessingAction == null ? queryResult : specification.PostProcessingAction(queryResult).ToList();
+        return specification.PostProcessingAction is null
+            ? queryResult
+            : specification.PostProcessingAction(queryResult).AsList();
     }
 
     /// <inheritdoc/>
@@ -77,7 +79,9 @@ public abstract class ContextFactoryRepositoryBaseOfT<TEntity, TContext> : IRepo
         await using var dbContext = _dbContextFactory.CreateDbContext();
         var queryResult = await ApplySpecification(specification, dbContext).ToListAsync(cancellationToken);
 
-        return specification.PostProcessingAction == null ? queryResult : specification.PostProcessingAction(queryResult).ToList();
+        return specification.PostProcessingAction is null
+            ? queryResult
+            : specification.PostProcessingAction(queryResult).AsList();
     }
 
     /// <inheritdoc/>

--- a/src/Ardalis.Specification.EntityFrameworkCore/Extensions/DbSetExtensions.cs
+++ b/src/Ardalis.Specification.EntityFrameworkCore/Extensions/DbSetExtensions.cs
@@ -10,9 +10,9 @@ public static class DbSetExtensions
     {
         var result = await SpecificationEvaluator.Default.GetQuery(source, specification).ToListAsync(cancellationToken);
 
-        return specification.PostProcessingAction == null
+        return specification.PostProcessingAction is null
             ? result
-            : specification.PostProcessingAction(result).ToList();
+            : specification.PostProcessingAction(result).AsList();
     }
 
     public static async Task<IEnumerable<TSource>> ToEnumerableAsync<TSource>(
@@ -23,7 +23,7 @@ public static class DbSetExtensions
     {
         var result = await SpecificationEvaluator.Default.GetQuery(source, specification).ToListAsync(cancellationToken);
 
-        return specification.PostProcessingAction == null
+        return specification.PostProcessingAction is null
             ? result
             : specification.PostProcessingAction(result);
     }

--- a/src/Ardalis.Specification.EntityFrameworkCore/RepositoryBaseOfT.cs
+++ b/src/Ardalis.Specification.EntityFrameworkCore/RepositoryBaseOfT.cs
@@ -131,7 +131,9 @@ public abstract class RepositoryBase<T> : IRepositoryBase<T> where T : class
     {
         var queryResult = await ApplySpecification(specification).ToListAsync(cancellationToken);
 
-        return specification.PostProcessingAction == null ? queryResult : specification.PostProcessingAction(queryResult).ToList();
+        return specification.PostProcessingAction is null
+            ? queryResult
+            : specification.PostProcessingAction(queryResult).AsList();
     }
 
     /// <inheritdoc/>
@@ -139,7 +141,9 @@ public abstract class RepositoryBase<T> : IRepositoryBase<T> where T : class
     {
         var queryResult = await ApplySpecification(specification).ToListAsync(cancellationToken);
 
-        return specification.PostProcessingAction == null ? queryResult : specification.PostProcessingAction(queryResult).ToList();
+        return specification.PostProcessingAction is null
+            ? queryResult
+            : specification.PostProcessingAction(queryResult).AsList();
     }
 
     /// <inheritdoc/>

--- a/src/Ardalis.Specification/CollectionExtensions.cs
+++ b/src/Ardalis.Specification/CollectionExtensions.cs
@@ -1,0 +1,14 @@
+﻿namespace Ardalis.Specification;
+
+internal static class CollectionExtensions
+{
+    public static List<T> AsList<T>(this IEnumerable<T> source)
+    {
+        if (source is List<T> list)
+        {
+            return list;
+        }
+
+        return source.ToList();
+    }
+}

--- a/src/Ardalis.Specification/Evaluators/InMemorySpecificationEvaluator.cs
+++ b/src/Ardalis.Specification/Evaluators/InMemorySpecificationEvaluator.cs
@@ -34,7 +34,7 @@ public class InMemorySpecificationEvaluator : IInMemorySpecificationEvaluator
           ? baseQuery.Select(specification.Selector.Compile())
           : baseQuery.SelectMany(specification.SelectorMany!.Compile());
 
-        return specification.PostProcessingAction == null
+        return specification.PostProcessingAction is null
             ? resultQuery
             : specification.PostProcessingAction(resultQuery);
     }
@@ -46,7 +46,7 @@ public class InMemorySpecificationEvaluator : IInMemorySpecificationEvaluator
             source = evaluator.Evaluate(source, specification);
         }
 
-        return specification.PostProcessingAction == null
+        return specification.PostProcessingAction is null
             ? source
             : specification.PostProcessingAction(source);
     }


### PR DESCRIPTION
Added `AsList` extension. If the `IEnumerable` source is a `List`, we return the list, otherwise, we create a new one.

The `PostProcessingAction` is a `Func<IEnumerable<T>, IEnumerable<T>>` delegate. However, users do not always filter the collection; they may just iterate over it and update items. In that case, if the delegate output is `List`, we may directly return it instead of allocating a new one.