### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We're shipping a built-in repository implementation [RepositoryBase](https://git
 
 ## Reference
 
-Please refer the documentation for [related resources](https://specification.ardalis.com/related-resources/).
+Please refer to the documentation for [related resources](https://specification.ardalis.com/related-resources/).
 
 Pluralsight resources:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 If you like or are using this project please give it a star. Thanks!
 # Specification
 
-Base class with tests for adding specifications to a DDD model. Also includes a default generic Repository base class with support for EF6 and EF Core. Currently used in Microsoft reference application [eShopOnWeb](https://github.com/dotnet-architecture/eShopOnWeb), which is the best place to see it in action, as well as the [Clean Architecture solution template](https://github.com/ardalis/cleanarchitecture). Check out Steve "ardalis" Smith's associated (free!) eBook, [Architecting Modern Web Applications with ASP.NET Core and Azure](https://aka.ms/webappebook), as well.
+A .NET library for building query specifications. Currently used in Microsoft reference application [eShopOnWeb](https://github.com/dotnet-architecture/eShopOnWeb), which is the best place to see it in action, as well as the [Clean Architecture solution template](https://github.com/ardalis/cleanarchitecture). Check out Steve "ardalis" Smith's associated (free!) eBook, [Architecting Modern Web Applications with ASP.NET Core and Azure](https://aka.ms/webappebook), as well.
 
 ## Documentation
 
@@ -29,11 +29,13 @@ The change log for `version 9` and the list of breaking changes can be found [he
 
 ## Sample Usage
 
-The Specification pattern pulls query-specific logic out of other places in the application where it currently exists. For applications with minimal abstraction that use EF Core directly, the specification will eliminate `Where`, `Include`, `Select` and similar expressions from almost all places where they're being used. In applications that abstract database query logic behind a `Repository` abstraction, the specification will typically eliminate the need for many custom `Repository` implementation classes as well as custom query methods on `Repository` implementations. Instead of many different ways to filter and shape data using various methods, the same capability is achieved with few core methods.
+The Specification pattern pulls query-specific logic out of other places in the application where it currently exists.
+- For applications with minimal abstraction that use EF Core directly, the specification will eliminate `Where`, `Include`, `Select` and similar expressions from almost all places where they're being used.
+- In applications that abstract database query logic behind a `Repository` abstraction, the specification will typically eliminate the need for many custom `Repository` implementation classes as well as custom query methods on `Repository` implementations. Instead of many different ways to filter and shape data using various methods, the same capability is achieved with few core methods.
 
 Example implementation in your repository using specifications
 
-```c#
+```charp
 public async Task<List<T>> ListAsync(ISpecification<T> specification, CancellationToken cancellationToken = default)
 {
     var query = SpecificationEvaluator.Default.GetQuery(_dbContext.Set<T>(), specification);
@@ -43,7 +45,7 @@ public async Task<List<T>> ListAsync(ISpecification<T> specification, Cancellati
 
 Now to use this method, the calling code simply instantiates and passes the appropriate specification.
 
-```c#
+```charp
 var spec = new CustomerByNameSpec("customerName");
 var customers = await _repository.ListAsync(spec, cancellationToken);
 ```
@@ -53,13 +55,7 @@ We're shipping a built-in repository implementation [RepositoryBase](https://git
 
 ## Reference
 
-Some free video streams in which this package has been developed and discussed on [YouTube.com/ardalis](http://youtube.com/ardalis?sub_confirmation=1).
-
-- [Reviewing the Specification Pattern and NuGet Package with guest Fiseni](https://www.youtube.com/watch?v=BgWWbBUWyig&t=315s&ab_channel=Ardalis) 6 Nov 2020
-- [Open Source .NET Development with Specification and Other Projects](https://www.youtube.com/watch?v=zP_279p2D9w) 14 Jan 2020
-- [Updating Specification and GuardClauses Nuget Packages / GitHub Samples](https://www.youtube.com/watch?v=kCeRJj2H1RQ) 20 Nov 2019
-- [Ardalis - Working on the Ardalis.Specification and EF Extensions GitHub projects](https://www.youtube.com/watch?v=PbHic9Ndqoc) 16 Aug 2019
-- [Working on the Ardalis.Specification Nuget Package and Integration Tests](https://www.youtube.com/watch?v=Ia3zb6-2LuY) 23 July 2019
+Please refer the documentation for [related resources](https://specification.ardalis.com/related-resources/).
 
 Pluralsight resources:
 


### PR DESCRIPTION
- Removed mentions of DDD. It gives the wrong impression that the library can be used only if DDD or clean architecture is applied.
- Removed video links. They're very old videos and may confuse users. We still have them in the docs, so we'll just refer to them.