### PR TITLE
Added Full Build workflow that publishes coverage reports.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Full Build
+
+on: 
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'tests/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.x
+    - name: Build
+      run: dotnet build ci.slnf --configuration Release
+    - name: Test
+      run: dotnet test ci.slnf --configuration Release --no-build --no-restore --framework net9.0 --collect:"XPlat Code Coverage;Format=opencover"
+    - name: ReportGenerator
+      uses: danielpalme/ReportGenerator-GitHub-Action@5.3.9
+      with:
+        reports: tests/**/coverage.opencover.xml
+        targetdir: ${{ runner.temp }}/coveragereport
+        reporttypes: 'Html;Badges;MarkdownSummaryGithub'
+        assemblyfilters: -*Tests*
+    - name: Publish coverage report in build summary
+      run: cat '${{ runner.temp }}'/coveragereport/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,6 @@ name: Build and Test
 
 on: 
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'src/**'
-      - 'tests/**'
   pull_request:
     branches:
       - main

--- a/Ardalis.Specification.sln
+++ b/Ardalis.Specification.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Items", "_Solutio
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
+		.github\workflows\build.yml = .github\workflows\build.yml
+		.github\workflows\ci.yml = .github\workflows\ci.yml
 		coverage.sh = coverage.sh
 		src\Directory.Build.props = src\Directory.Build.props
 		tests\Directory.Build.props = tests\Directory.Build.props
@@ -26,6 +28,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Items", "_Solutio
 		exclusion.dic = exclusion.dic
 		readme-nuget.md = readme-nuget.md
 		README.md = README.md
+		.github\workflows\release.yml = .github\workflows\release.yml
 		setup-sqllocaldb.ps1 = setup-sqllocaldb.ps1
 	EndProjectSection
 EndProject


### PR DESCRIPTION
Added new workflow that collects and publishes coverage reports. For now, we'll publish them just as markdown in the job summary page. Also modified the triggers as follows:
- `ci.yml` - it will be triggered for pull requests only. It builds and tests.
- `build.yml` - it will be triggered on push to main. It builds, tests, generates a coverage report, and publishes to the job summary page. 