### PR TITLE
Rename TagWithEvaluator to QueryTagEvaluator.

### DIFF
--- a/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/QueryTagEvaluator.cs
+++ b/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/QueryTagEvaluator.cs
@@ -1,9 +1,9 @@
 ﻿namespace Ardalis.Specification.EntityFrameworkCore;
 
-public class TagWithEvaluator : IEvaluator
+public class QueryTagEvaluator : IEvaluator
 {
-    private TagWithEvaluator() { }
-    public static TagWithEvaluator Instance { get; } = new TagWithEvaluator();
+    private QueryTagEvaluator() { }
+    public static QueryTagEvaluator Instance { get; } = new QueryTagEvaluator();
 
     public bool IsCriteriaEvaluator { get; } = true;
 
@@ -15,8 +15,7 @@ public class TagWithEvaluator : IEvaluator
 
             if (spec.OneOrManyQueryTags.HasSingleItem)
             {
-                query = query.TagWith(spec.OneOrManyQueryTags.Single);
-                return query;
+                return query.TagWith(spec.OneOrManyQueryTags.Single);
             }
         }
 

--- a/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SpecificationEvaluator.cs
+++ b/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SpecificationEvaluator.cs
@@ -28,7 +28,7 @@ public class SpecificationEvaluator : ISpecificationEvaluator
             IgnoreQueryFiltersEvaluator.Instance,
             IgnoreAutoIncludesEvaluator.Instance,
             AsSplitQueryEvaluator.Instance,
-            TagWithEvaluator.Instance,
+            QueryTagEvaluator.Instance,
         ];
     }
 

--- a/tests/Ardalis.Specification.EntityFrameworkCore.Tests/Evaluators/QueryTagEvaluatorTests.cs
+++ b/tests/Ardalis.Specification.EntityFrameworkCore.Tests/Evaluators/QueryTagEvaluatorTests.cs
@@ -1,9 +1,9 @@
 ﻿namespace Tests.Evaluators;
 
 [Collection("SharedCollection")]
-public class TagWithEvaluatorTests(TestFactory factory) : IntegrationTest(factory)
+public class QueryTagEvaluatorTests(TestFactory factory) : IntegrationTest(factory)
 {
-    private static readonly TagWithEvaluator _evaluator = TagWithEvaluator.Instance;
+    private static readonly QueryTagEvaluator _evaluator = QueryTagEvaluator.Instance;
 
     [Fact]
     public void QueriesMatch_GivenTag()

--- a/tests/Ardalis.Specification.EntityFrameworkCore.Tests/Evaluators/SpecificationEvaluatorTests.cs
+++ b/tests/Ardalis.Specification.EntityFrameworkCore.Tests/Evaluators/SpecificationEvaluatorTests.cs
@@ -359,7 +359,7 @@ public class SpecificationEvaluatorTests(TestFactory factory) : IntegrationTest(
         result[10].Should().BeOfType<IgnoreQueryFiltersEvaluator>();
         result[11].Should().BeOfType<IgnoreAutoIncludesEvaluator>();
         result[12].Should().BeOfType<AsSplitQueryEvaluator>();
-        result[13].Should().BeOfType<TagWithEvaluator>();
+        result[13].Should().BeOfType<QueryTagEvaluator>();
         result[14].Should().BeOfType<WhereEvaluator>();
     }
 


### PR DESCRIPTION
The `TagWithEvaluator` is a weird name. It will be a minor breaking change for those using partial evaluators directly, but it was introduced relatively recently. Let's rename it now before it gets stuck forever.