### PR TITLE
Add a fallback to LINQ for search evaluators/validator in case of custom user specifications.

### DIFF
--- a/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SearchEvaluator.cs
+++ b/src/Ardalis.Specification.EntityFrameworkCore/Evaluators/SearchEvaluator.cs
@@ -26,6 +26,15 @@ public class SearchEvaluator : IEvaluator
         }
 
 
+        // We'll never reach this point for our specifications.
+        // This is just to cover the case where users have custom ISpecification<T> implementation but use our evaluator.
+        // We'll fall back to LINQ for this case.
+
+        foreach (var searchGroup in specification.SearchCriterias.GroupBy(x => x.SearchGroup))
+        {
+            query = query.ApplyLikesAsOrGroup(searchGroup);
+        }
+
         return query;
     }
 

--- a/src/Ardalis.Specification/Ardalis.Specification.csproj
+++ b/src/Ardalis.Specification/Ardalis.Specification.csproj
@@ -27,6 +27,7 @@
     <InternalsVisibleTo Include="Ardalis.Specification.EntityFrameworkCore" />
     <InternalsVisibleTo Include="Ardalis.Specification.EntityFramework6" />
     <InternalsVisibleTo Include="Ardalis.Specification.Tests" />
+    <InternalsVisibleTo Include="Ardalis.Specification.EntityFrameworkCore.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Ardalis.Specification/Evaluators/SearchMemoryEvaluator.cs
+++ b/src/Ardalis.Specification/Evaluators/SearchMemoryEvaluator.cs
@@ -22,6 +22,15 @@ public class SearchMemoryEvaluator : IInMemoryEvaluator
             return new SpecLikeIterator<T>(query, spec.OneOrManySearchExpressions.List);
         }
 
+        // We'll never reach this point for our specifications.
+        // This is just to cover the case where users have custom ISpecification<T> implementation but use our evaluator.
+        // We'll fall back to LINQ for this case.
+
+        foreach (var searchGroup in specification.SearchCriterias.GroupBy(x => x.SearchGroup))
+        {
+            query = query.Where(x => searchGroup.Any(c => c.SelectorFunc(x)?.Like(c.SearchTerm) ?? false));
+        }
+
         return query;
     }
 

--- a/src/Ardalis.Specification/Validators/SearchValidator.cs
+++ b/src/Ardalis.Specification/Validators/SearchValidator.cs
@@ -20,6 +20,15 @@ public class SearchValidator : IValidator
             return IsValid(entity, spec.OneOrManySearchExpressions.List);
         }
 
+        // We'll never reach this point for our specifications.
+        // This is just to cover the case where users have custom ISpecification<T> implementation but use our validator.
+        // We'll fall back to LINQ for this case.
+
+        foreach (var searchGroup in specification.SearchCriterias.GroupBy(x => x.SearchGroup))
+        {
+            if (searchGroup.Any(c => c.SelectorFunc(entity)?.Like(c.SearchTerm) ?? false) == false) return false;
+        }
+
         return true;
     }
 

--- a/src/Ardalis.Specification/Validators/SearchValidator.cs
+++ b/src/Ardalis.Specification/Validators/SearchValidator.cs
@@ -26,13 +26,14 @@ public class SearchValidator : IValidator
 
         foreach (var searchGroup in specification.SearchCriterias.GroupBy(x => x.SearchGroup))
         {
-            if (searchGroup.Any(c => c.SelectorFunc(entity)?.Like(c.SearchTerm) ?? false) == false) return false;
+            if (!searchGroup.Any(c => c.SelectorFunc(entity)?.Like(c.SearchTerm) ?? false))
+                return false;
         }
 
         return true;
     }
 
-    // This would be simpler using Span<SearchExpressionInfo<TSource>>
+    // This would be simpler using Span<SearchExpressionInfo<T>>
     // but CollectionsMarshal.AsSpan is not available in .NET Standard 2.0
     private static bool IsValid<T>(T entity, List<SearchExpressionInfo<T>> list)
     {

--- a/tests/Ardalis.Specification.EntityFrameworkCore.Tests/Evaluators/SearchEvaluatorCustomSpecTests.cs
+++ b/tests/Ardalis.Specification.EntityFrameworkCore.Tests/Evaluators/SearchEvaluatorCustomSpecTests.cs
@@ -1,0 +1,105 @@
+﻿namespace Tests.Evaluators;
+
+// This is a special case where users have custom ISpecification<T> implementation but use our evaluator.
+[Collection("SharedCollection")]
+public class SearchEvaluatorCustomSpecTests(TestFactory factory) : IntegrationTest(factory)
+{
+    private static readonly SearchEvaluator _evaluator = SearchEvaluator.Instance;
+
+    [Fact]
+    public void QueriesMatch_GivenNoSearch()
+    {
+        var spec = new CustomSpecification<Store>();
+        spec.Where.Add(new WhereExpressionInfo<Store>(x => x.Id > 0));
+
+        var actual = _evaluator.GetQuery(DbContext.Stores, spec)
+            .ToQueryString();
+
+        var expected = DbContext.Stores
+            .ToQueryString();
+
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void QueriesMatch_GivenSingleSearch()
+    {
+        var storeTerm = "ab1";
+
+        var spec = new CustomSpecification<Store>();
+        spec.Where.Add(new WhereExpressionInfo<Store>(x => x.Id > 0));
+        spec.Search.Add(new SearchExpressionInfo<Store>(x => x.Name, $"%{storeTerm}%"));
+
+        var actual = _evaluator.GetQuery(DbContext.Stores, spec)
+            .ToQueryString();
+
+        var expected = DbContext.Stores
+            .Where(x => EF.Functions.Like(x.Name, $"%{storeTerm}%"))
+            .ToQueryString();
+
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void QueriesMatch_GivenMultipleSearch()
+    {
+        var storeTerm = "ab1";
+        var companyTerm = "ab2";
+        var countryTerm = "ab3";
+        var streetTerm = "ab4";
+
+        var spec = new CustomSpecification<Store>();
+        spec.Where.Add(new WhereExpressionInfo<Store>(x => x.Id > 0));
+        spec.Search.Add(new SearchExpressionInfo<Store>(x => x.Name, $"%{storeTerm}%"));
+        spec.Search.Add(new SearchExpressionInfo<Store>(x => x.Company.Name, $"%{companyTerm}%"));
+        spec.Search.Add(new SearchExpressionInfo<Store>(x => x.Address.Street, $"%{streetTerm}%", 2));
+        spec.Search.Add(new SearchExpressionInfo<Store>(x => x.Company.Country.Name, $"%{countryTerm}%", 3));
+
+        var actual = _evaluator.GetQuery(DbContext.Stores, spec)
+            .ToQueryString();
+
+        var expected = DbContext.Stores
+            .Where(x => EF.Functions.Like(x.Name, $"%{storeTerm}%")
+                    || EF.Functions.Like(x.Company.Name, $"%{companyTerm}%"))
+            .Where(x => EF.Functions.Like(x.Address.Street, $"%{streetTerm}%"))
+            .Where(x => EF.Functions.Like(x.Company.Country.Name, $"%{countryTerm}%"))
+            .ToQueryString();
+
+        actual.Should().Be(expected);
+    }
+
+    public class CustomSpecification<T> : ISpecification<T>
+    {
+        public List<WhereExpressionInfo<T>> Where { get; set; } = new();
+        public List<SearchExpressionInfo<T>> Search { get; set; } = new();
+        public IEnumerable<SearchExpressionInfo<T>> SearchCriterias => Search;
+        public IEnumerable<WhereExpressionInfo<T>> WhereExpressions => Where;
+
+        public ISpecificationBuilder<T> Query => throw new NotImplementedException();
+        public IEnumerable<OrderExpressionInfo<T>> OrderExpressions => throw new NotImplementedException();
+        public IEnumerable<IncludeExpressionInfo> IncludeExpressions => throw new NotImplementedException();
+        public IEnumerable<string> IncludeStrings => throw new NotImplementedException();
+        public Dictionary<string, object> Items => throw new NotImplementedException();
+        public int Take => throw new NotImplementedException();
+        public int Skip => throw new NotImplementedException();
+        public Func<IEnumerable<T>, IEnumerable<T>>? PostProcessingAction => throw new NotImplementedException();
+        public IEnumerable<string> QueryTags => throw new NotImplementedException();
+        public bool CacheEnabled => throw new NotImplementedException();
+        public string? CacheKey => throw new NotImplementedException();
+        public bool AsTracking => throw new NotImplementedException();
+        public bool AsNoTracking => throw new NotImplementedException();
+        public bool AsSplitQuery => throw new NotImplementedException();
+        public bool AsNoTrackingWithIdentityResolution => throw new NotImplementedException();
+        public bool IgnoreQueryFilters => throw new NotImplementedException();
+        public bool IgnoreAutoIncludes => throw new NotImplementedException();
+        public IEnumerable<T> Evaluate(IEnumerable<T> entities)
+            => throw new NotImplementedException();
+        public bool IsSatisfiedBy(T entity)
+            => throw new NotImplementedException();
+
+        void ISpecification<T>.CopyTo(Specification<T> otherSpec)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Ardalis.Specification.Tests/Validators/SearchValidatorCustomSpecTests.cs
+++ b/tests/Ardalis.Specification.Tests/Validators/SearchValidatorCustomSpecTests.cs
@@ -1,0 +1,201 @@
+﻿namespace Tests.Validators;
+
+// This is a special case where users have custom ISpecification<T> implementations but use our validator.
+public class SearchValidatorCustomSpecTests
+{
+    private static readonly SearchValidator _validator = SearchValidator.Instance;
+
+    public record Customer(int Id, string FirstName, string? LastName);
+
+    [Fact]
+    public void ReturnsTrue_GivenEmptySpec()
+    {
+        var customer = new Customer(1, "FirstName1", "LastName1");
+
+        var spec = new CustomSpecification<Customer>();
+
+        var result = _validator.IsValid(customer, spec);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReturnsTrue_GivenNoSearch()
+    {
+        var customer = new Customer(1, "FirstName1", "LastName1");
+
+        var spec = new CustomSpecification<Customer>();
+        spec.Where.Add(new WhereExpressionInfo<Customer>(x => x.Id == 1));
+
+        var result = _validator.IsValid(customer, spec);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReturnsTrue_GivenSpecWithSingleSearch_WithValidEntity()
+    {
+        var customer = new Customer(1, "FirstName1", "LastName1");
+
+        var term = "irst";
+        var spec = new CustomSpecification<Customer>();
+        spec.Search.Add(new SearchExpressionInfo<Customer>(x => x.FirstName, $"%{term}%"));
+
+        var result = _validator.IsValid(customer, spec);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReturnsFalse_GivenSpecWithSingleSearch_WithInvalidEntity()
+    {
+        var customer = new Customer(1, "FirstName1", "LastName1");
+
+        var term = "irstt";
+        var spec = new CustomSpecification<Customer>();
+        spec.Search.Add(new SearchExpressionInfo<Customer>(x => x.FirstName, $"%{term}%"));
+
+        var result = _validator.IsValid(customer, spec);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsFalse_GivenSpecWithSingleSearch_WithNullProperty()
+    {
+        var customer = new Customer(1, "FirstName1", null);
+
+        var term = "irst";
+        var spec = new CustomSpecification<Customer>();
+        spec.Search.Add(new SearchExpressionInfo<Customer>(x => x.LastName, $"%{term}%"));
+
+        var result = _validator.IsValid(customer, spec);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrue_GivenSpecWithMultipleSearchSameGroup_WithValidEntity()
+    {
+        var customer = new Customer(1, "FirstName1", "LastName1");
+
+        var term = "irst";
+        var spec = new CustomSpecification<Customer>();
+        spec.Search.Add(new SearchExpressionInfo<Customer>(x => x.FirstName, $"%{term}%"));
+        spec.Search.Add(new SearchExpressionInfo<Customer>(x => x.LastName, $"%{term}%"));
+
+        var result = _validator.IsValid(customer, spec);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReturnsFalse_GivenSpecWithMultipleSearchSameGroup_WithInvalidEntity()
+    {
+        var customer = new Customer(1, "FirstName1", "LastName1");
+
+        var term = "irstt";
+        var spec = new CustomSpecification<Customer>();
+        spec.Search.Add(new SearchExpressionInfo<Customer>(x => x.FirstName, $"%{term}%"));
+        spec.Search.Add(new SearchExpressionInfo<Customer>(x => x.LastName, $"%{term}%"));
+
+        var result = _validator.IsValid(customer, spec);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrue_GivenSpecWithMultipleSearchDifferentGroup_WithValidEntity()
+    {
+        var customer = new Customer(1, "FirstName1", "LastName1");
+
+        var term = "Name";
+        var spec = new CustomSpecification<Customer>();
+        spec.Search.Add(new SearchExpressionInfo<Customer>(x => x.FirstName, $"%{term}%", 1));
+        spec.Search.Add(new SearchExpressionInfo<Customer>(x => x.LastName, $"%{term}%", 2));
+
+        var result = _validator.IsValid(customer, spec);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReturnsFalse_GivenSpecWithMultipleSearchDifferentGroup_WithInvalidEntity()
+    {
+        var customer = new Customer(1, "FirstName1", "LastName1");
+
+        var term = "irst";
+        var spec = new CustomSpecification<Customer>();
+        spec.Search.Add(new SearchExpressionInfo<Customer>(x => x.FirstName, $"%{term}%", 1));
+        spec.Search.Add(new SearchExpressionInfo<Customer>(x => x.LastName, $"%{term}%", 2));
+
+        var result = _validator.IsValid(customer, spec);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrue_GivenSpecWithMultipleSearchSameGroup_WithNullProperty()
+    {
+        var customer = new Customer(1, "FirstName1", null);
+
+        var term = "irst";
+        var spec = new CustomSpecification<Customer>();
+        spec.Search.Add(new SearchExpressionInfo<Customer>(x => x.FirstName, $"%{term}%", 1));
+        spec.Search.Add(new SearchExpressionInfo<Customer>(x => x.LastName, $"%{term}%", 1));
+
+        var result = _validator.IsValid(customer, spec);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReturnsFalse_GivenSpecWithMultipleSearchDifferentGroup_WithNullProperty()
+    {
+        var customer = new Customer(1, "FirstName1", null);
+
+        var term = "irst";
+        var spec = new CustomSpecification<Customer>();
+        spec.Search.Add(new SearchExpressionInfo<Customer>(x => x.FirstName, $"%{term}%", 1));
+        spec.Search.Add(new SearchExpressionInfo<Customer>(x => x.LastName, $"%{term}%", 2));
+
+        var result = _validator.IsValid(customer, spec);
+
+        result.Should().BeFalse();
+    }
+
+    public class CustomSpecification<T> : ISpecification<T>
+    {
+        public List<WhereExpressionInfo<T>> Where { get; set; } = new();
+        public List<SearchExpressionInfo<T>> Search { get; set; } = new();
+        public IEnumerable<SearchExpressionInfo<T>> SearchCriterias => Search;
+        public IEnumerable<WhereExpressionInfo<T>> WhereExpressions => Where;
+
+        public ISpecificationBuilder<T> Query => throw new NotImplementedException();
+        public IEnumerable<OrderExpressionInfo<T>> OrderExpressions => throw new NotImplementedException();
+        public IEnumerable<IncludeExpressionInfo> IncludeExpressions => throw new NotImplementedException();
+        public IEnumerable<string> IncludeStrings => throw new NotImplementedException();
+        public Dictionary<string, object> Items => throw new NotImplementedException();
+        public int Take => throw new NotImplementedException();
+        public int Skip => throw new NotImplementedException();
+        public Func<IEnumerable<T>, IEnumerable<T>>? PostProcessingAction => throw new NotImplementedException();
+        public IEnumerable<string> QueryTags => throw new NotImplementedException();
+        public bool CacheEnabled => throw new NotImplementedException();
+        public string? CacheKey => throw new NotImplementedException();
+        public bool AsTracking => throw new NotImplementedException();
+        public bool AsNoTracking => throw new NotImplementedException();
+        public bool AsSplitQuery => throw new NotImplementedException();
+        public bool AsNoTrackingWithIdentityResolution => throw new NotImplementedException();
+        public bool IgnoreQueryFilters => throw new NotImplementedException();
+        public bool IgnoreAutoIncludes => throw new NotImplementedException();
+        public IEnumerable<T> Evaluate(IEnumerable<T> entities)
+            => throw new NotImplementedException();
+        public bool IsSatisfiedBy(T entity)
+            => throw new NotImplementedException();
+
+        void ISpecification<T>.CopyTo(Specification<T> otherSpec)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
This is just to cover the case where users have a custom `ISpecification<T>` implementation but use our evaluator.
It's highly unlikely that anyone does that, but we'll add a fallback to LINQ for the sake of completeness.